### PR TITLE
Easier config objects

### DIFF
--- a/examples/inputs.py
+++ b/examples/inputs.py
@@ -1,61 +1,90 @@
+import sys
+
 import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
 
-config = tfe.LocalConfig(5)
-# config = tfe.RemoteConfig(
-#     player_hosts=[
-#         'localhost:4440',
-#         'localhost:4441',
-#         'localhost:4442'
-#     ]
-# )
+config = tfe.LocalConfig([
+    'server0',
+    'server1',
+    'crypto_producer',
+    'weights_provider',
+    'prediction_client'
+])
 
-class WeightsInputProvider(tfe.io.InputProvider):
+# config = tfe.RemoteConfig([
+#     ('server0', 'localhost:4440'),
+#     ('server1', 'localhost:4441'),
+#     ('crypto_producer', 'localhost:4442'),
+#     ('weights_provider', 'localhost:4443'),
+#     ('prediction_client', 'localhost:4444')
+# ])
 
-    def provide_input(self) -> tf.Tensor:
-        raw_weights = np.array([1, 2, 3, 4]).reshape((2,2))
-        return tf.constant(raw_weights)
+if len(sys.argv) > 1:
 
-class PredictionInputProvider(tfe.io.InputProvider):
+    #
+    # assume we're running as a server
+    #
 
-    def provide_input(self) -> tf.Tensor:
-        return tf.constant([1, 2, 3, 4], shape=(2,2), dtype=tf.float32)
+    player_name = str(sys.argv[1])
 
-class PredictionOutputReceiver(tfe.io.OutputReceiver):
+    server = config.server(player_name)
+    server.start()
+    server.join()
 
-    def receive_output(self, tensor: tf.Tensor) -> tf.Operation:
-        return tf.Print(tensor, [tensor])
+else:
 
-weights_input = WeightsInputProvider(config.players[3])
-prediction_input = PredictionInputProvider(config.players[3])
-prediction_output = PredictionOutputReceiver(config.players[4])
+    #
+    # assume we're running as master
+    #
 
-with tfe.protocol.Pond(*config.players[:3]) as prot:
+    class WeightsInputProvider(tfe.io.InputProvider):
 
-    # # treat weights as private
-    # initial_w = prot.define_private_input(weights_input)
-    # w = prot.define_private_variable(initial_w)
+        def provide_input(self) -> tf.Tensor:
+            raw_w = np.array([5, 5, 5, 5]).reshape((2,2))
+            w = tf.constant(raw_w)
+            return tf.Print(w, [w])
 
-    # treat weights as private, but initial value as public
-    # initial_w = prot.define_public_input(weights_input)
-    # w = prot.define_private_variable(initial_w)
+    class PredictionInputProvider(tfe.io.InputProvider):
 
-    # treat weights as public
-    initial_w = prot.define_public_input(weights_input)
-    w = prot.define_public_variable(initial_w)
+        def provide_input(self) -> tf.Tensor:
+            x = tf.constant([1, 2, 3, 4], shape=(2,2), dtype=tf.float32)
+            return tf.Print(x, [x])
 
-    # load input for prediction
-    x = prot.define_private_input(prediction_input)
+    class PredictionOutputReceiver(tfe.io.OutputReceiver):
 
-    # compute prediction
-    y = x.dot(w)
+        def receive_output(self, tensor: tf.Tensor) -> tf.Operation:
+            return tf.Print(tensor, [tensor])
 
-    # send output
-    prediction_op = prot.define_output(y, prediction_output)
-    
-    with config.session() as sess:
-        tfe.run(sess, tf.global_variables_initializer(), tag='init')
+    weights_input = WeightsInputProvider(config.get_player('weights_provider'))
+    prediction_input = PredictionInputProvider(config.get_player('prediction_client'))
+    prediction_output = PredictionOutputReceiver(config.get_player('prediction_client'))
 
-        for _ in range(5):
-            tfe.run(sess, prediction_op, tag='prediction')
+    with tfe.protocol.Pond(*config.get_players('server0, server1, crypto_producer')) as prot:
+
+        # # treat weights as private
+        # initial_w = prot.define_private_input(weights_input)
+        # w = prot.define_private_variable(initial_w)
+
+        # treat weights as private, but initial value as public
+        # initial_w = prot.define_public_input(weights_input)
+        # w = prot.define_private_variable(initial_w)
+
+        # treat weights as public
+        initial_w = prot.define_public_input(weights_input)
+        w = prot.define_public_variable(initial_w)
+
+        # load input for prediction
+        x = prot.define_private_input(prediction_input)
+
+        # compute prediction
+        y = x.dot(w)
+
+        # send output
+        prediction_op = prot.define_output(y, prediction_output)
+
+        with config.session() as sess:
+            tfe.run(sess, tf.global_variables_initializer(), tag='init')
+
+            for _ in range(5):
+                tfe.run(sess, prediction_op, tag='prediction')

--- a/examples/matmul.py
+++ b/examples/matmul.py
@@ -2,7 +2,11 @@ import numpy as np
 import tensorflow_encrypted as tfe
 
 # use local config (for development/debugging)
-config = tfe.LocalConfig(3)
+config = tfe.LocalConfig([
+    'server0',
+    'server1',
+    'crypto_producer'
+])
 
 # use remote config
 # config = tfe.RemoteConfig([
@@ -14,7 +18,7 @@ config = tfe.LocalConfig(3)
 # use remote config from cluster file
 # config = tfe.RemoteConfig.from_file('cluster.json')
 
-with tfe.protocol.Pond(*config.players) as prot:
+with tfe.protocol.Pond(*config.get_players('server0, server1, crypto_producer')) as prot:
 
     w = prot.define_private_variable(np.zeros((100, 100)))
     # x = prot.define_private_variable(np.zeros((1,100)))

--- a/examples/pond-logreg.py
+++ b/examples/pond-logreg.py
@@ -3,9 +3,13 @@ import tensorflow_encrypted as tfe
 
 from tensorflow_encrypted.protocol import Pond
 
-config = tfe.LocalConfig(3)
+config = tfe.LocalConfig([
+    'server0',
+    'server1',
+    'crypto_producer'
+])
 
-prot = Pond(*config.players)
+prot = Pond(*config.get_players('server0, server1, crypto_producer'))
 
 # parameters
 np_w = np.array([.1, .2, .3, .4]).reshape(2, 2)

--- a/examples/pond-simple.py
+++ b/examples/pond-simple.py
@@ -2,9 +2,13 @@ import numpy as np
 import tensorflow_encrypted as tfe
 from tensorflow_encrypted.protocol import Pond
 
-config = tfe.LocalConfig(3)
+config = tfe.LocalConfig([
+    'server0',
+    'server1',
+    'crypto_producer'
+])
 
-prot = Pond(*config.players)
+prot = Pond(*config.get_players('server0, server1, crypto_producer'))
 
 # a = prot.define_constant(np.array([4, 3, 2, 1]).reshape(2,2))
 # b = prot.define_constant(np.array([4, 3, 2, 1]).reshape(2,2))

--- a/examples/pond.py
+++ b/examples/pond.py
@@ -5,9 +5,13 @@ import tensorflow_encrypted as tfe
 from tensorflow_encrypted.protocol import Pond
 from tensorflow_encrypted.layer import Conv2D
 
-config = tfe.LocalConfig(3)
+config = tfe.LocalConfig([
+    'server0',
+    'server1',
+    'crypto_producer'
+])
 
-with Pond(*config.players) as prot:
+with tfe.protocol.Pond(*config.get_players('server0, server1, crypto_producer')) as prot:
 
     a = prot.define_constant(np.array([4, 3, 2, 1]).reshape(2, 2))
     b = prot.define_constant(np.array([4, 3, 2, 1]).reshape(2, 2))

--- a/examples/server.py
+++ b/examples/server.py
@@ -1,16 +1,14 @@
 import sys
 import tensorflow_encrypted as tfe
 
-task_index = int(sys.argv[1])
+player_name = str(sys.argv[1])
 
-config = tfe.RemoteConfig(
-    player_hosts=[
-        'localhost:4440',
-        'localhost:4441',
-        'localhost:4442'
-    ]
-)
+config = tfe.RemoteConfig({
+    'server0': 'localhost:4440',
+    'server1': 'localhost:4441',
+    'crypto_producer': 'localhost:4442'
+})
 
-server = config.server(task_index)
+server = config.server(player_name)
 server.start()
 server.join()

--- a/tensorflow_encrypted/config.py
+++ b/tensorflow_encrypted/config.py
@@ -15,24 +15,34 @@ class LocalConfig(object):
     Intended mostly for development/debugging use.
     """
 
-    def __init__(self, num_players: int, job_name: str='localhost') -> None:
-        self.num_players = num_players
-        self.job_name = job_name
-
-    @property
-    def players(self) -> List[Player]:
-        return [
-            Player(
-                '/job:{job_name}/replica:0/task:0/device:CPU:{cpu_id}'.format(
-                    job_name=self.job_name,
-                    # swift by one to allow for master to be `CPU:0`
+    def __init__(self, player_names:List[str], job_name:str='localhost') -> None:
+        self._players = {
+            name: Player(
+                name=name,
+                index=index+1,
+                device_name='/job:{job_name}/replica:0/task:0/device:CPU:{cpu_id}'.format(
+                    job_name=job_name,
+                    # shift by one to allow for master to be `CPU:0`
                     cpu_id=index+1
                 )
             )
-            for index in range(self.num_players)
-        ]
+            for index, name in enumerate(player_names)
+        }
 
-    def session(self, log_device_placement: bool=False) -> tf.Session:
+    @property
+    def players(self) -> List[Player]:
+        return self._players.values()
+
+    def get_player(self, name:str) -> Player:
+        return self._players[name]
+
+    def get_players(self, names:Union[List[str], str]) -> List[Player]:
+        if isinstance(names, str):
+            names = [name.strip() for name in names.split(',')]
+        assert isinstance(names, list)
+        return [player for name, player in self._players.items() if name in names]
+
+    def session(self, log_device_placement:bool=False) -> tf.Session:
         # reserve one CPU for the player executing the script, to avoid
         # default pinning of operations to one of the actual players
         return tf.Session(
@@ -41,7 +51,7 @@ class LocalConfig(object):
             config=tf.ConfigProto(
                 log_device_placement=log_device_placement,
                 allow_soft_placement=False,
-                device_count={"CPU": self.num_players + 1},
+                device_count={"CPU": len(self._players) + 1},
                 inter_op_parallelism_threads=1,
                 intra_op_parallelism_threads=1
             )
@@ -53,58 +63,72 @@ class RemoteConfig(object):
     Configure tf-encrypted to use network hosts for the different players.
     """
 
-    def __init__(self, player_hosts: List[str],
+    def __init__(self,
+                 player_hostmap: Union[List[Tuple[str,str]], Dict[str, str]],
                  master_host: Optional[str]=None,
                  job_name: str='tfe') -> None:
 
-        self.player_hosts = player_hosts
-        self.master_host = master_host
-        self.job_name = job_name
+        self._job_name = job_name
+
+        if isinstance(player_hostmap, dict):
+            # ensure consistent ordering of the players across all instances
+            player_hostmap = list(sorted(player_hostmap.items()))
+
+        player_names, player_hosts = zip(*player_hostmap)
+
+        if master_host is None:
+            # use first player as master so don't add any
+            self._offset = 0
+            self._hostmap = player_hosts
+            self._target = 'grpc://{}'.format(player_hosts[0])
+        else:
+            # add explicit master to cluster as first host
+            self._offset = 1
+            self._hostmap = (master_host,) + player_hosts
+            self._target = 'grpc://{}'.format(master_host)
+
+        self._players = {
+            name: Player(
+                name=name,
+                index=index+self._offset,
+                device_name='/job:{job_name}/replica:0/task:{task_id}/cpu:0'.format(
+                    job_name=job_name,
+                    task_id=index+self._offset
+                ),
+                host=host
+            )
+            for index, (name, host) in enumerate(zip(player_names, player_hosts))
+        }
 
     @property
     def players(self) -> List[Player]:
-        if self.master_host is None:
-            offset = 0
-        else:
-            offset = 1
+        return self._players.values()
 
-        return [
-            Player('/job:{job_name}/replica:0/task:{task_id}/cpu:0'.format(
-                job_name=self.job_name,
-                task_id=index+offset
-            ))
-            for index in range(len(self.player_hosts))
-        ]
+    def get_player(self, name:str) -> Player:
+        return self._players[name]
 
-    def server(self, player_index: int) -> tf.train.Server:
-        if self.master_host is None:
-            # use first player as master so don't add any
-            cluster = tf.train.ClusterSpec({self.job_name: self.player_hosts})
-            return tf.train.Server(cluster, job_name=self.job_name,
-                                   task_index=player_index)
-        else:
-            # add explicit master to cluster
-            cluster = tf.train.ClusterSpec(
-                {self.job_name: [self.master_host] + self.player_hosts}
-            )
-            return tf.train.Server(cluster, job_name=self.job_name,
-                                   task_index=player_index+1)
+    def get_players(self, names:Union[List[str], str]) -> List[Player]:
+        if isinstance(names, str):
+            names = [name.strip() for name in names.split(',')]
+        assert isinstance(names, list)
+        return [player for name, player in self._players.items() if name in names]
 
-    def session(self, log_device_placement: bool=False) -> tf.Session:
-        if self.master_host is None:
-            # use first player as master
-            target = 'grpc://{}'.format(self.player_hosts[0])
-        else:
-            # use specified master
-            target = 'grpc://{}'.format(self.master_host)
+    def server(self, name:str) -> tf.train.Server:
+        player = self.get_player(name)
+        cluster = tf.train.ClusterSpec({self._job_name: self._hostmap})
+        return tf.train.Server(
+            cluster,
+            job_name=self._job_name,
+            task_index=player.index
+        )
 
+    def session(self, log_device_placement:bool=False) -> tf.Session:
         config = tf.ConfigProto(
             log_device_placement=log_device_placement,
             allow_soft_placement=False,
         )
-
         return tf.Session(
-            target,
+            self._target,
             config=config
         )
 

--- a/tensorflow_encrypted/player.py
+++ b/tensorflow_encrypted/player.py
@@ -1,4 +1,8 @@
+from typing import Optional
 
 class Player(object):
-    def __init__(self, device_name: str) -> None:
-        self.device_name = device_name
+    def __init__(self, name:str, index:int, device_name:str, host:Optional[str]=None) -> None:
+        self.name=name
+        self.index=index
+        self.device_name=device_name
+        self.host=host

--- a/tests/conv2d_test.py
+++ b/tests/conv2d_test.py
@@ -18,10 +18,14 @@ class TestConv2D(unittest.TestCase):
         filter_shape = (h_filter, w_filter, channels_in, channels_out)
         filter_values = np.random.normal(size=filter_shape)
 
-        config = tfe.LocalConfig(3)
+        config = tfe.LocalConfig([
+            'server0',
+            'server1',
+            'crypto_producer'
+        ])
 
         # convolution pond
-        with tfe.protocol.Pond(*config.players) as prot:
+        with tfe.protocol.Pond(*config.get_players('server0, server1, crypto_producer')) as prot:
         
             conv_input = prot.define_private_variable(input_conv)
             conv_layer = tfe.layer.Conv2D(filter_shape, strides=2)

--- a/tests/relu_test.py
+++ b/tests/relu_test.py
@@ -10,10 +10,14 @@ class TestRelu(unittest.TestCase):
     def test_forward(self):
         input_relu = np.array([-1.0, -0.5, 0.5, 3.0]).astype(np.float32)
 
-        config = tfe.LocalConfig(3)
+        config = tfe.LocalConfig([
+            'server0',
+            'server1',
+            'crypto_producer'
+        ])
 
         # relu pond
-        with tfe.protocol.Pond(*config.players) as prot:
+        with tfe.protocol.Pond(*config.get_players('server0, server1, crypto_producer')) as prot:
 
             relu_input = prot.define_private_variable(input_relu)
             relu_layer = Relu()


### PR DESCRIPTION
Closes #48 

Allows us to use names of hosts/players instead of index, eg:

```python
config = tfe.RemoteConfig({
     'server0': 'localhost:4440',
     'server1': 'localhost:4441',
     'crypto_producer': 'localhost:4442',
     'weights_provider': 'localhost:4443',
     'prediction_client': 'localhost:4444'
})

server0 = config.get_player('server0')
```
and `$ python3 server.py server0`

instead of 
```python
config = tfe.RemoteConfig([
     'localhost:4440',
     'localhost:4441',
     'localhost:4442',
     'localhost:4443',
     'localhost:4444'
})

server0 = config.players[0]
```
and `$ python3 server 0`