### PR TITLE
Safe truncate

### DIFF
--- a/tensorflow_encrypted/__init__.py
+++ b/tensorflow_encrypted/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from .config import run, LocalConfig, RemoteConfig, setTFEDebugFlag, setMonitorStatsFlag
 from .protocol import global_caches_updator
+from .player import player
 from . import io
 from . import protocol
 from . import layers
@@ -14,6 +15,7 @@ __all__ = [
     "setTFEDebugFlag",
     "setMonitorStatsFlag",
     "io",
+    "player",
     "protocol",
     "layers",
     "convert",

--- a/tensorflow_encrypted/player/__init__.py
+++ b/tensorflow_encrypted/player/__init__.py
@@ -4,5 +4,6 @@ from .player import Player
 
 __all__ = [
     'Player',
+    'player',
     '__main__',
 ]

--- a/tensorflow_encrypted/player/player.py
+++ b/tensorflow_encrypted/player/player.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+import tensorflow as tf
+
 
 class Player(object):
     def __init__(self, name: str, index: int, device_name: str, host: Optional[str] = None) -> None:
@@ -7,3 +9,7 @@ class Player(object):
         self.index = index
         self.device_name = device_name
         self.host = host
+
+
+def player(player: Player):
+    return tf.device(player.device_name)

--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -18,7 +18,7 @@ from ..tensor.helpers import (
     inverse
 )
 from ..io import InputProvider, OutputReceiver
-from ..player import Player, player
+from ..player import Player
 from .protocol import Protocol, _global_cache_updators
 
 TFEData = Union[np.ndarray, tf.Tensor]
@@ -50,7 +50,7 @@ class Pond(Protocol):
         server_0: Player,
         server_1: Player,
         crypto_producer: Player,
-        use_interactive_truncation: bool=False
+        use_interactive_truncation: bool=True
     ) -> None:
         self.server_0 = server_0
         self.server_1 = server_1

--- a/tensorflow_encrypted/tensor/crt.py
+++ b/tensorflow_encrypted/tensor/crt.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import numpy as np
 import tensorflow as tf
 
-from .helpers import inverse, prod, log2
+from .helpers import inverse, prod
 
 
 def gen_crt_decompose(m):

--- a/tensorflow_encrypted/tensor/crt.py
+++ b/tensorflow_encrypted/tensor/crt.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import numpy as np
 import tensorflow as tf
 
-from .helpers import inverse, prod
+from .helpers import inverse, prod, log2
 
 
 def gen_crt_decompose(m):
@@ -52,7 +52,7 @@ def gen_crt_recombine_explicit(m, int_type):
                         [ti.astype(float) / mi for ti, mi in zip(t, m)],
                         axis=0
                     ))
-                u = np.sum((ti * bi for ti, bi in zip(t, b)), axis=0).astype(np.int64)
+                u = np.sum([ti * bi for ti, bi in zip(t, b)], axis=0).astype(np.int64)
                 v = alpha.astype(np.int64) * B
                 w = u - v
                 res = w % bound
@@ -171,6 +171,33 @@ def gen_crt_sample_uniform(m, int_type):
             return [tf.random_uniform(shape, maxval=mi, dtype=int_type) for mi in m]
 
     return crt_sample_uniform
+
+
+def gen_crt_sample_bounded(m, int_type):
+
+    CHUNK_MAX_BITLENGTH = 30  # TODO[Morten] bump to full range once signed numbers is settled (change minval etc)
+    add = gen_crt_add(m)
+    mul = gen_crt_mul(m)
+    decompose = gen_crt_decompose(m)
+
+    def crt_sample_bounded(shape, bitlength):
+
+        with tf.name_scope('sample_bounded'):
+            q, r = bitlength // CHUNK_MAX_BITLENGTH, bitlength % CHUNK_MAX_BITLENGTH
+            chunk_sizes = [CHUNK_MAX_BITLENGTH] * q + [r]
+
+            result = decompose(0)
+            for chunk_size in chunk_sizes:
+                chunk_value = tf.random_uniform(shape, minval=0, maxval=2**chunk_size, dtype=int_type)
+                scale = 2**chunk_size
+                result = add(
+                    mul(result, decompose(scale)),
+                    decompose(chunk_value)
+                )
+
+        return result
+
+    return crt_sample_bounded
 
 
 def gen_crt_mod(m, int_type):

--- a/tensorflow_encrypted/tensor/int100.py
+++ b/tensorflow_encrypted/tensor/int100.py
@@ -7,8 +7,9 @@ from typing import Union, Optional, List, Dict, Any
 
 from .crt import (
     gen_crt_decompose, gen_crt_recombine_lagrange, gen_crt_recombine_explicit,
-    gen_crt_add, gen_crt_sub, gen_crt_mul, gen_crt_dot, gen_crt_im2col, gen_crt_mod,
-    gen_crt_sample_uniform, gen_crt_sum
+    gen_crt_add, gen_crt_sub, gen_crt_mul, gen_crt_dot, gen_crt_mod,
+    gen_crt_sum, gen_crt_im2col,
+    gen_crt_sample_uniform, gen_crt_sample_bounded
 )
 from .helpers import prod, log2
 from ..config import run
@@ -44,6 +45,7 @@ _crt_im2col = gen_crt_im2col(m)
 _crt_mod = gen_crt_mod(m, INT_TYPE)
 
 _crt_sample_uniform = gen_crt_sample_uniform(m, INT_TYPE)
+_crt_sample_bounded = gen_crt_sample_bounded(m, INT_TYPE)
 
 
 class Int100Tensor(object):
@@ -88,6 +90,10 @@ class Int100Tensor(object):
     @staticmethod
     def sample_uniform(shape: List[int]) -> 'Int100Tensor':
         return _sample_uniform(shape)
+
+    @staticmethod
+    def sample_bounded(shape: List[int], bitlength: int) -> 'Int100Tensor':
+        return _sample_bounded(shape, bitlength)
 
     def __repr__(self) -> str:
         return 'Int100Tensor({})'.format(self.shape)
@@ -213,6 +219,11 @@ def _mod(x, k):
 
 def _sample_uniform(shape):
     backing = _crt_sample_uniform(shape)
+    return Int100Tensor.from_decomposed(backing)
+
+
+def _sample_bounded(shape, bitlength):
+    backing = _crt_sample_bounded(shape, bitlength)
     return Int100Tensor.from_decomposed(backing)
 
 

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -1,0 +1,42 @@
+import unittest
+
+import numpy as np
+import tensorflow as tf
+import tensorflow_encrypted as tfe
+from tensorflow_encrypted.layers import Reshape
+
+
+class TestReshape(unittest.TestCase):
+    def setUp(self):
+        tf.reset_default_graph()
+
+    def test_truncate(self):
+
+        config = tfe.LocalConfig([
+            'server0',
+            'server1',
+            'crypto_producer'
+        ])
+
+        server0, server1, cp = config.get_players('server0, server1, crypto_producer')
+
+        prot = tfe.protocol.Pond(
+            server0, server1, cp,
+            use_interactive_truncation=True
+        )
+
+        with config.session() as sess:
+
+            expected = np.array([12345.6789])
+
+            w = prot.define_private_variable(expected * (2**16))  # double precision
+            v = prot.truncate(w)  # single precision
+
+            sess.run(tf.global_variables_initializer())
+            actual = v.reveal().eval(sess, tag='foo')
+
+            assert np.isclose(actual, expected).all(), actual
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -5,11 +5,11 @@ import tensorflow as tf
 import tensorflow_encrypted as tfe
 
 
-class TestReshape(unittest.TestCase):
+class TestTruncate(unittest.TestCase):
     def setUp(self):
         tf.reset_default_graph()
 
-    def test_truncate(self):
+    def test_interactive_truncate(self):
 
         config = tfe.LocalConfig([
             'server0',
@@ -22,6 +22,33 @@ class TestReshape(unittest.TestCase):
         prot = tfe.protocol.Pond(
             server0, server1, cp,
             use_interactive_truncation=True
+        )
+
+        with config.session() as sess:
+
+            expected = np.array([12345.6789])
+
+            w = prot.define_private_variable(expected * (2**16))  # double precision
+            v = prot.truncate(w)  # single precision
+
+            sess.run(tf.global_variables_initializer())
+            actual = v.reveal().eval(sess, tag='foo')
+
+            assert np.isclose(actual, expected).all(), actual
+
+    def test_noninteractive_truncate(self):
+
+        config = tfe.LocalConfig([
+            'server0',
+            'server1',
+            'crypto_producer'
+        ])
+
+        server0, server1, cp = config.get_players('server0, server1, crypto_producer')
+
+        prot = tfe.protocol.Pond(
+            server0, server1, cp,
+            use_interactive_truncation=False
         )
 
         with config.session() as sess:

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -3,7 +3,6 @@ import unittest
 import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
-from tensorflow_encrypted.layers import Reshape
 
 
 class TestReshape(unittest.TestCase):


### PR DESCRIPTION
Implements the CS'10 truncation protocol in case the failure probability of the non-interaction protocol is too high for a given application. This is now the protocol used by default, but the non-interaction version can be turned on as an optimization by specifying `use_interaction_truncation=False` when creating the Pond instance

Closes https://github.com/partydb/tf-encrypted/issues/65