### PR TITLE
Publish releases to pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TensorFlow Encrypted
 
+![CircleCI Badge](https://circleci.com/gh/mortendahl/tf-encrypted/tree/master.svg?style=svg) [GitHub](https://img.shields.io/github/license/mortendahl/tf-encrypted.svg) ![PyPI](https://img.shields.io/pypi/v/tf-encrypted.svg)
+
 This library provides a layer on top of TensorFlow for doing machine learning on encrypted data as initially described in [Secure Computations as Dataflow Programs](https://mortendahl.github.io/2018/03/01/secure-computation-as-dataflow-programs/), with the aim of making it easy for researchers and practitioners to experiment with private machine learning using familiar tools and without being an expert in both machine learning and cryptography. To this end the code is structured into roughly three modules:
 
 - secure operations for computing on encrypted tensors
@@ -35,7 +37,7 @@ with tfe.protocol.Pond(server0, server1, crypto_producer) as prot:
     result_op = prot.define_output([result], result_receiver)
 
     with config.session() as sess:
-        tfe.run(sess, tf.global_variables_initializer())            
+        tfe.run(sess, tf.global_variables_initializer())
         tfe.run(sess, result_op, tag='average')
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,16 +6,17 @@ GitHub and then runs the build. If it passes, then the `deploy` job will run
 which will trigger the `make push` rule in our Makefile which will subseuqently
 build and push all release artifacts.
 
-Today, the only release artifact produced from this repository is a
-[Docker](https://www.docker.com) container.
+Today, the following artifacts are produced from this repository:
 
-If a release candidate (e.g. `X.Y.Z-rc.#`) is pushed then Circle CI will build
-the container (`mortendahl/tf-encrypted:X.Y.Z-rc.#`) and push it to Docker Hub
-*without* updating the `mortendahl/tf-encrypted:latest` tag.
+- a docker container which is available on docker hub as [mortendahl/tf-encrypted](https://hub.docker.com/r/mortendahl/tf-encrypted/))
+- a python package registered on pypi as [tf-encrypted](https://pypi.org/project/tf-encrypted)
 
-If a release tag (e.g. `X.Y.Z`) is pushed then Circle CI will build the
-containers and push both `mortendahl/tf-encrypted:X.Y.Z` and
-`mortendahl/tf-encrypted:lateset` to Docker Hub.
+If a release candidate tag (e.g. `X.Y.Z-rc#`) is pushed then Circle CI will
+build these artifacts and push them to the their respective repositories. A
+release candidate *will not* update the `latest` tag on docker hub.
+
+If a release tag (e.g. `X.Y.Z`) is pushed then Circle CI will build and push
+all artifacts along with updating the `latest` tag on docker hub.
 
 ### Whats the flow?
 
@@ -25,9 +26,9 @@ tf-encrypted below:
 
 1. Create a Release Candidate by creating a tag on master in the form of
    `X.Y.Z-rc.#`. If this is the first release candidate in the series for this
-   tag the number should begin at 0 (e.g. `git tag 0.1.0-rc.0`).
+   tag the number should begin at 0 (e.g. `git tag 0.1.0-rc0`).
 2. Push the tag up to GitHub which will trigger a build in Circle CI (e.g. `git
-   push origin 0.1.0-rc.0`). Once this build is complete, Circle CI will build
+   push origin 0.1.0-rc0`). Once this build is complete, Circle CI will build
    the release artifacts to their respective repositories (Docker Hub, etc.).
 3. Test the Release Artifact to make sure it passes our bar of quality. If any
    bugs are found or other quality issues create a new release candidate by
@@ -35,8 +36,12 @@ tf-encrypted below:
    Candidate version!
 4. Once we're satisfied with the quality of the release candidate, it's time to
    cut the actual release! This is done once again by creating a tag without
-   the `-rc.#` (e.g. `git tag 0.1.0`) and push it again (e.g. `git push origin
+   the `-rc#` (e.g. `git tag 0.1.0`) and push it again (e.g. `git push origin
    0.1.0`). Once the build is done, the release is available in the wild!
+
+**NOTE**: You must update *and* commit to master a new version of `setup.py`
+everytime you want to tag a new version of `tf-encrypted`. Make sure you push
+the changes to `master` of [tf-encrypted on github](https://github.com/mortendahl/tf-encrypted).
 
 Have a question about the process or have a suggestion on how to improve it?
 Don't hesitate to open an [issue](https://github.com/mortendahl/tf-encrypted/issues/new)
@@ -44,12 +49,12 @@ with your thoughts!
 
 ### Whats with the tags?
 
-Development follows [`semver v2.0`](https://semver.org/) versioning
-specification. If the major has changed (e.g. the X in `X.Y.Z`) then a breaking
-API change has occurred requiring any dependent users to make changes to their
-code. If the minor (e.g. the Y in `X.Y.Z`) has changed then one or more new
-features have been added. While if the patch has changed (e.g. the Z in
-`X.Y.Z`) then only a fix has been implemented.
+This project follows the [PEP 440](https://www.python.org/dev/peps/pep-0440/)
+versioning specification. If the major has changed (e.g. the X in `X.Y.Z`) then
+a breaking API change has occurred requiring any dependent users to make
+changes to their code. If the minor (e.g. the Y in `X.Y.Z`) has changed then
+one or more new features have been added. While if the patch has changed (e.g.
+the Z in `X.Y.Z`) then only a fix has been implemented.
 
 This makes it easy for developers of tf-encrypted and users alike to communicate
 about the risk involved in uptaking a new version of tf-encrypted.

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,34 @@
-from setuptools import setup
+import setuptools
 
-setup(
-    name='tf-encrypted',
-    version='0.0.1-rc',
-    packages=['tensorflow_encrypted'],
-    python_requires='>=3.6',
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="tf-encrypted",
+    version="0.0.1-rc0",
+    packages=setuptools.find_packages(),
+    python_requires=">=3.6",
     install_requires=[
-        'tensorflow>=1.10.0',
-        'numpy>=1.14.0'
+        "tensorflow>=1.10.0",
+        "numpy>=1.14.0"
     ],
     extra_requires={
-        'tf': ["tensorflow>=1.10.0"],
-        'tf_gpu': ["tensorflow-gpu>=1.10.0"]
+        "tf": ["tensorflow>=1.10.0"],
+        "tf_gpu": ["tensorflow-gpu>=1.10.0"]
     },
-    license='Apache License 2.0',
+    license="Apache License 2.0",
     url="https://github.com/mortendahl/tf-encrypted",
-    description='Layer on top of TensorFlow for doing machine learning on encrypted data.',
+    description="Layer on top of TensorFlow for doing machine learning on encrypted data.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="Morten Dahl",
+    author_email="morten@dropoutlabs.com",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Development Status :: 2 - Pre-Alpha",
+        "Operating System :: OS Independent",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Security :: Cryptography"
+    ]
 )


### PR DESCRIPTION
This commit adds rules to the Makefile for publishing artifacts to the
[pypi](https://pypi.org) package repository by introducing a new set of
`pypi-*` rules that mirror the behaviour of the docker ruleset.

I've updated the RELEASING.md file to reflect the changes to our release
workflow and the new artifacts this repository now produces.

Closes #28