### PR TITLE
link README badges to real content rather than the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TensorFlow Encrypted
 
-![CircleCI Badge](https://circleci.com/gh/mortendahl/tf-encrypted/tree/master.svg?style=svg) ![GitHub](https://img.shields.io/github/license/mortendahl/tf-encrypted.svg) ![PyPI](https://img.shields.io/pypi/v/tf-encrypted.svg)
+[![CircleCI Badge](https://circleci.com/gh/mortendahl/tf-encrypted/tree/master.svg?style=svg)](https://circleci.com/gh/mortendahl/tf-encrypted/tree/master) [![GitHub](https://img.shields.io/github/license/mortendahl/tf-encrypted.svg)](./LICENSE) [![PyPI](https://img.shields.io/pypi/v/tf-encrypted.svg)](https://pypi.org/project/tf-encrypted/)
 
 This library provides a layer on top of TensorFlow for doing machine learning on encrypted data as initially described in [Secure Computations as Dataflow Programs](https://mortendahl.github.io/2018/03/01/secure-computation-as-dataflow-programs/), with the aim of making it easy for researchers and practitioners to experiment with private machine learning using familiar tools and without being an expert in both machine learning and cryptography. To this end the code is structured into roughly three modules:
 


### PR DESCRIPTION
build -> to the circle ci build page
license -> to the license page on github
pypi -> to the pypi project page