### PR TITLE
add a note to run tools/gcp commands from that directory

### DIFF
--- a/tools/gcp/README.md
+++ b/tools/gcp/README.md
@@ -4,6 +4,8 @@ A few tools for making it slightly easier to run experiments on the Google Cloud
 
 All steps here assume that the [Cloud SDK](https://cloud.google.com/sdk/) has already been installed (for macOS this may be done via e.g. Homebrew: `brew cask install google-cloud-sdk`) and a project set up.
 
+It also assumes that you are running the commands from this directory (`cd tools/gcp/` from the project root.)
+
 ## Base image
 
 We first create a base image with all needed software for future GCP instances running TensorFlow Encrypted. To that end we start with a template instance whos disk turns into the image.
@@ -50,4 +52,4 @@ If we wish to clean up fully the base image can also be deleted with
 ```shell
 gcloud compute images delete tfe-image --quiet
 ```
-If you encountered an error when creating the image tfe-image from the tfe-template, it's probably because you already had the image tfe-image created. For this reason you might have to run the command above as well. 
+If you encountered an error when creating the image tfe-image from the tfe-template, it's probably because you already had the image tfe-image created. For this reason you might have to run the command above as well.


### PR DESCRIPTION
You get to this README via a link from the root README, but it's not
immediately obvious that you should switch to this directory to run
the commands.

For example, if you stay in the root and try to follow along, you will
fail on the second command

`gcloud compute ssh tfe-template < debian-install.sh` because `debian-install.sh`
will not be found.