### PR TITLE
Bugfix for masked conv2d in pond

### DIFF
--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -2460,7 +2460,7 @@ def _reshape_masked(prot, x: PondMaskedTensor, shape: List[int]) -> PondMaskedTe
             a1_reshaped = a1.reshape(shape)
             alpha_on_1_reshaped = alpha_on_1.reshape(shape)
 
-        x_unmasked_reshaped = prot.reshape(x.unmasked)
+        x_unmasked_reshaped = prot.reshape(x.unmasked, shape)
 
     return PondMaskedTensor(
         prot,


### PR DESCRIPTION
Previously, a reshape at the end of conv2d wasn't being passed a new shape, causing Pond.conv2d to error out.