### PR TITLE
Hack: SecureNN Experiment Benchmarks

### DIFF
--- a/examples/securenn/conv_convert.py
+++ b/examples/securenn/conv_convert.py
@@ -1,0 +1,43 @@
+
+#
+# Based on:
+# - https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/how_tos/reading_data/convert_to_records.py
+# - https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/how_tos/reading_data/fully_connected_reader.py
+#
+
+import tensorflow as tf
+
+
+def encode_image(value):
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value.tostring()]))
+
+
+def decode_image(value):
+    image = tf.decode_raw(value, tf.uint8)
+    image = tf.reshape(image, (1, 28, 28))
+    return image
+
+
+def encode_label(value):
+    return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
+
+
+def decode_label(value):
+    return tf.cast(value, tf.int32)
+
+
+def encode(image, label):
+    return tf.train.Example(features=tf.train.Features(feature={
+        'image': encode_image(image),
+        'label': encode_label(label)
+    }))
+
+
+def decode(serialized_example):
+    features = tf.parse_single_example(serialized_example, features={
+        'image': tf.FixedLenFeature([], tf.string),
+        'label': tf.FixedLenFeature([], tf.int64)
+    })
+    image = decode_image(features['image'])
+    label = decode_label(features['label'])
+    return image, label

--- a/examples/securenn/network_a.py
+++ b/examples/securenn/network_a.py
@@ -52,18 +52,18 @@ class ModelTrainer(tfe.io.InputProvider):
     def build_training_graph(self, training_data) -> List[tf.Tensor]:
         j = self.IN_N
         k = self.HIDDEN_N
-        l = self.OUT_N
+        m = self.OUT_N
         r_in = math.sqrt(12 / (j + k))
         r_hid = math.sqrt(12 / (2 * k))
-        r_out = math.sqrt(12 / (k + l))
+        r_out = math.sqrt(12 / (k + m))
 
         # model parameters and initial values
         w0 = tf.Variable(tf.random_uniform([j, k], minval=-r_in, maxval=r_in))
         b0 = tf.Variable(tf.zeros([k]))
         w1 = tf.Variable(tf.random_uniform([k, k], minval=-r_hid, maxval=r_hid))
         b1 = tf.Variable(tf.zeros([k]))
-        w2 = tf.Variable(tf.random_uniform([k, 10], minval=-r_out, maxval=r_out))
-        b2 = tf.Variable(tf.zeros([10]))
+        w2 = tf.Variable(tf.random_uniform([k, m], minval=-r_out, maxval=r_out))
+        b2 = tf.Variable(tf.zeros([m]))
         params = [w0, b0, w1, b1, w2, b2]
 
         # optimizer and data pipeline

--- a/examples/securenn/network_b.py
+++ b/examples/securenn/network_b.py
@@ -200,7 +200,7 @@ with tfe.protocol.Pond(server0, server1, crypto_producer) as prot:
     bconv2 = prot.reshape(bconv2, [-1, 1, 1])
     layer1 = pool(prot.relu(conv(x, Wconv1) + bconv1))
     layer2 = pool(prot.relu(conv(layer1, Wconv2) + bconv2))
-    layer2 = prot.reshape(layer2, [-1, self.HIDDEN_FC1])
+    layer2 = prot.reshape(layer2, [-1, ModelTrainer.HIDDEN_FC1])
     layer3 = prot.dot(layer2, Wfc1) + bfc1
     logits = prot.dot(layer3, Wfc2) + bfc2
 

--- a/examples/securenn/network_b.py
+++ b/examples/securenn/network_b.py
@@ -1,0 +1,220 @@
+from __future__ import absolute_import
+import sys
+from typing import List
+import math
+
+import tensorflow as tf
+import tensorflow_encrypted as tfe
+
+from examples.securenn.conv_convert import decode
+
+
+if len(sys.argv) >= 2:
+    # config file was specified
+    config_file = sys.argv[1]
+    config = tfe.config.load(config_file)
+else:
+    # default to using local config
+    config = tfe.LocalConfig([
+        'server0',
+        'server1',
+        'crypto-producer',
+        'model-trainer',
+        'prediction-client'
+    ])
+
+
+def weight_variable(shape, gain):
+    """weight_variable generates a weight variable of a given shape."""
+    if len(shape) == 2:
+        fan_in, fan_out = shape
+    elif len(shape) == 4:
+        h, w, c_in, c_out = shape
+        fan_in = h * w * c_in
+        fan_out = h * w * c_out
+    r = gain * math.sqrt(6 / (fan_in + fan_out))
+    initial = tf.random_uniform(shape, minval=-r, maxval=r)
+    return tf.Variable(initial)
+
+
+def bias_variable(shape):
+    """bias_variable generates a bias variable of a given shape."""
+    initial = tf.constant(0., shape=shape)
+    return tf.Variable(initial)
+
+
+conv2d = lambda x, w, s: tf.nn.conv2d(x, w, strides=[1, s, s, 1], padding='VALID')
+pooling = lambda x: tf.nn.avg_pool(x, [1, 2, 2, 1], [1, 2, 2, 1], 'VALID')
+
+
+class ModelTrainer(tfe.io.InputProvider):
+
+    BATCH_SIZE = 32
+    ITERATIONS = 60000 // BATCH_SIZE
+    EPOCHS = 15
+    IN_DIM = 28
+    KERNEL = 5
+    STRIDE = 1
+    IN_CHANNELS = 1
+    HIDDEN_CHANNELS = 16
+    HIDDEN_FC1 = 256
+    HIDDEN_FC2 = 100
+    OUT_N = 10
+
+    def build_data_pipeline(self):
+
+        def normalize(image, label):
+            x = tf.cast(image, tf.float32) / 255.
+            image = (x - 0.1307) / 0.3081  # image = (x - mean) / std
+            return image, label
+
+        dataset = tf.data.TFRecordDataset(["./data/train.tfrecord"])
+        dataset = dataset.map(decode)
+        dataset = dataset.map(normalize)
+        dataset = dataset.repeat()
+        dataset = dataset.batch(self.BATCH_SIZE)
+
+        iterator = dataset.make_one_shot_iterator()
+        return iterator
+
+    def build_training_graph(self, training_data) -> List[tf.Tensor]:
+
+        # model parameters and initial values
+        Wconv1 = weight_variable([self.KERNEL,
+                                  self.KERNEL,
+                                  self.IN_CHANNELS,
+                                  self.HIDDEN_CHANNELS], 1.)
+        bconv1 = bias_variable([1, 1, self.HIDDEN_CHANNELS])
+        Wconv2 = weight_variable([self.KERNEL,
+                                  self.KERNEL,
+                                  self.HIDDEN_CHANNELS,
+                                  self.HIDDEN_CHANNELS], 1.)
+        bconv2 = bias_variable([1, 1, self.HIDDEN_CHANNELS])
+        Wfc1 = weight_variable([self.HIDDEN_FC1, self.HIDDEN_FC2], 1.)
+        bfc1 = bias_variable([self.HIDDEN_FC2])
+        Wfc2 = weight_variable([self.HIDDEN_FC2, self.OUT_N], 1.)
+        bfc2 = bias_variable([self.OUT_N])
+        params = [Wconv1, bconv1, Wconv2, bconv2, Wfc1, bfc1, Wfc2, bfc2]
+
+        # optimizer and data pipeline
+        optimizer = tf.train.AdamOptimizer(learning_rate=0.01)
+
+        # training loop
+        def loop_body(i):
+
+            # get next batch
+            x, y = training_data.get_next()
+
+            # model construction
+            x = tf.reshape(x, [-1, self.IN_DIM, self.IN_DIM, 1])
+            layer1 = pooling(tf.nn.relu(conv2d(x, Wconv1, self.STRIDE) + bconv1))
+            layer2 = pooling(tf.nn.relu(conv2d(layer1, Wconv2, self.STRIDE) + bconv2))
+            layer2 = tf.reshape(layer2, [-1, self.HIDDEN_FC1])
+            layer3 = tf.nn.relu(tf.matmul(layer2, Wfc1) + bfc1)
+            logits = tf.matmul(layer3, Wfc2) + bfc2
+
+            loss = tf.reduce_mean(tf.losses.sparse_softmax_cross_entropy(logits=logits, labels=y))
+            with tf.control_dependencies([optimizer.minimize(loss)]):
+                return i + 1
+
+        loop = tf.while_loop(lambda i: i < self.ITERATIONS * self.EPOCHS, loop_body, (0,))
+
+        # return model parameters after training
+        loop = tf.Print(loop, [], message="Training complete")
+        with tf.control_dependencies([loop]):
+            return [param.read_value() for param in params]
+
+    def provide_input(self) -> List[tf.Tensor]:
+        with tf.name_scope('loading'):
+            training_data = self.build_data_pipeline()
+
+        with tf.name_scope('training'):
+            parameters = self.build_training_graph(training_data)
+
+        return parameters
+
+
+class PredictionClient(tfe.io.InputProvider, tfe.io.OutputReceiver):
+
+    BATCH_SIZE = 20
+    HIDDEN_FC1 = 256
+
+    def build_data_pipeline(self):
+
+        def normalize(image, label):
+            x = tf.cast(image, tf.float32) / 255.
+            image = (x - 0.1307) / 0.3081  # image = (x - mean) / std
+            return image, label
+
+        dataset = tf.data.TFRecordDataset(["./data/test.tfrecord"])
+        dataset = dataset.map(decode)
+        dataset = dataset.map(normalize)
+        dataset = dataset.batch(self.BATCH_SIZE)
+
+        iterator = dataset.make_one_shot_iterator()
+        return iterator
+
+    def provide_input(self) -> List[tf.Tensor]:
+        with tf.name_scope('loading'):
+            prediction_input, expected_result = self.build_data_pipeline().get_next()
+            prediction_input = tf.Print(prediction_input, [expected_result], summarize=self.BATCH_SIZE, message="EXPECT ")
+
+        with tf.name_scope('pre-processing'):
+            prediction_input = tf.reshape(prediction_input, shape=(self.BATCH_SIZE, 1, 28, 28))
+
+        return [prediction_input]
+
+    def receive_output(self, tensors: List[tf.Tensor]) -> tf.Operation:
+        likelihoods, = tensors
+        with tf.name_scope('post-processing'):
+            prediction = tf.argmax(likelihoods, axis=1)
+            op = tf.Print([], [prediction], summarize=self.BATCH_SIZE, message="ACTUAL ")
+            return op
+
+
+model_trainer = ModelTrainer(config.get_player('model-trainer'))
+prediction_client = PredictionClient(config.get_player('prediction-client'))
+
+server0 = config.get_player('server0')
+server1 = config.get_player('server1')
+crypto_producer = config.get_player('crypto-producer')
+
+with tfe.protocol.Pond(server0, server1, crypto_producer) as prot:
+
+    # get model parameters as private tensors from model owner
+    params = prot.define_private_input(model_trainer, masked=True)  # pylint: disable=E0632
+
+    # we'll use the same parameters for each prediction so we cache them to avoid re-training each time
+    params = prot.cache(params)
+
+    # get prediction input from client
+    x, = prot.define_private_input(prediction_client, masked=True)  # pylint: disable=E0632
+
+    # helpers
+    conv = lambda x, w: prot.conv2d(x, w, 1, 'VALID')
+    pool = lambda x: prot.avgpool2d(x, (2, 2), (2, 2), 'VALID')
+
+    # compute prediction
+    Wconv1, bconv1, Wconv2, bconv2, Wfc1, bfc1, Wfc2, bfc2 = params
+    bconv1 = prot.reshape(bconv1, [-1, 1, 1])
+    bconv2 = prot.reshape(bconv2, [-1, 1, 1])
+    layer1 = pool(prot.relu(conv(x, Wconv1) + bconv1))
+    layer2 = pool(prot.relu(conv(layer1, Wconv2) + bconv2))
+    layer2 = prot.reshape(layer2, [-1, self.HIDDEN_FC1])
+    layer3 = prot.dot(layer2, Wfc1) + bfc1
+    logits = prot.dot(layer3, Wfc2) + bfc2
+
+    # send prediction output back to client
+    prediction_op = prot.define_output([logits], prediction_client)
+
+
+with config.session() as sess:
+    print("Init")
+    tfe.run(sess, tf.global_variables_initializer(), tag='init')
+
+    print("Training")
+    tfe.run(sess, tfe.global_caches_updator(), tag='training')
+
+    for _ in range(5):
+        print("Predicting")
+        tfe.run(sess, prediction_op, tag='prediction')

--- a/examples/securenn/network_c.py
+++ b/examples/securenn/network_c.py
@@ -1,0 +1,224 @@
+from __future__ import absolute_import
+import sys
+from typing import List
+import math
+
+import tensorflow as tf
+import tensorflow_encrypted as tfe
+
+from examples.securenn.conv_convert import decode
+
+
+if len(sys.argv) >= 2:
+    # config file was specified
+    config_file = sys.argv[1]
+    config = tfe.config.load(config_file)
+else:
+    # default to using local config
+    config = tfe.LocalConfig([
+        'server0',
+        'server1',
+        'crypto-producer',
+        'model-trainer',
+        'prediction-client'
+    ])
+
+
+def weight_variable(shape, gain):
+    """weight_variable generates a weight variable of a given shape."""
+    if len(shape) == 2:
+        fan_in, fan_out = shape
+    elif len(shape) == 4:
+        h, w, c_in, c_out = shape
+        fan_in = h * w * c_in
+        fan_out = h * w * c_out
+    r = gain * math.sqrt(6 / (fan_in + fan_out))
+    initial = tf.random_uniform(shape, minval=-r, maxval=r)
+    return tf.Variable(initial)
+
+
+def bias_variable(shape):
+    """bias_variable generates a bias variable of a given shape."""
+    initial = tf.constant(0., shape=shape)
+    return tf.Variable(initial)
+
+
+conv2d = lambda x, w, s: tf.nn.conv2d(x, w, strides=[1, s, s, 1], padding='VALID')
+pooling = lambda x: tf.nn.avg_pool(x, [1, 2, 2, 1], [1, 2, 2, 1], 'VALID')
+
+
+class ModelTrainer(tfe.io.InputProvider):
+    BATCH_SIZE = 32
+    ITERATIONS = 60000 // BATCH_SIZE
+    EPOCHS = 15
+    IN_DIM = 28
+    KERNEL = 5
+    STRIDE = 1
+    IN_CHANNELS = 1
+    HIDDEN_C1 = 6
+    HIDDEN_C2 = 16
+    HIDDEN_FC1 = 256
+    HIDDEN_FC2 = 120
+    HIDDEN_FC3 = 84
+    OUT_N = 10
+
+    def build_data_pipeline(self):
+
+        def normalize(image, label):
+            x = tf.cast(image, tf.float32) / 255.
+            image = (x - 0.1307) / 0.3081  # image = (x - mean) / std
+            return image, label
+
+        dataset = tf.data.TFRecordDataset(["./data/train.tfrecord"])
+        dataset = dataset.map(decode)
+        dataset = dataset.map(normalize)
+        dataset = dataset.repeat()
+        dataset = dataset.batch(self.BATCH_SIZE)
+
+        iterator = dataset.make_one_shot_iterator()
+        return iterator
+
+    def build_training_graph(self, training_data) -> List[tf.Tensor]:
+
+        # model parameters and initial values
+        Wconv1 = weight_variable([self.KERNEL,
+                                  self.KERNEL,
+                                  self.IN_CHANNELS,
+                                  self.HIDDEN_C1], 1.)
+        bconv1 = bias_variable([1, 1, self.HIDDEN_C1])
+        Wconv2 = weight_variable([self.KERNEL,
+                                  self.KERNEL,
+                                  self.HIDDEN_C1,
+                                  self.HIDDEN_C2], 1.)
+        bconv2 = bias_variable([1, 1, self.HIDDEN_C2])
+        Wfc1 = weight_variable([self.HIDDEN_FC1, self.HIDDEN_FC2], 1.)
+        bfc1 = bias_variable([self.HIDDEN_FC2])
+        Wfc2 = weight_variable([self.HIDDEN_FC2, self.HIDDEN_FC3], 1.)
+        bfc2 = bias_variable([self.HIDDEN_FC3])
+        Wfc3 = weight_variable([self.HIDDEN_FC3, self.OUT_N], 1.)
+        bfc3 = bias_variable([self.OUT_N])
+        params = [Wconv1, bconv1, Wconv2, bconv2, Wfc1, bfc1, Wfc2, bfc2, Wfc3, bfc3]
+
+        # optimizer and data pipeline
+        optimizer = tf.train.AdamOptimizer(learning_rate=0.01)
+
+        # training loop
+        def loop_body(i):
+
+            # get next batch
+            x, y = training_data.get_next()
+
+            # model construction
+            x = tf.reshape(x, [-1, self.IN_DIM, self.IN_DIM, 1])
+            layer1 = pooling(tf.nn.relu(conv2d(x, Wconv1, self.STRIDE) + bconv1))
+            layer2 = pooling(tf.nn.relu(conv2d(layer1, Wconv2, self.STRIDE) + bconv2))
+            layer2 = tf.reshape(layer2, [-1, self.HIDDEN_FC1])
+            layer3 = tf.nn.relu(tf.matmul(layer2, Wfc1) + bfc1)
+            layer4 = tf.nn.relu(tf.matmul(layer3, Wfc2) + bfc2)
+            logits = tf.matmul(layer4, Wfc3) + bfc3
+
+            loss = tf.reduce_mean(tf.losses.sparse_softmax_cross_entropy(logits=logits, labels=y))
+            with tf.control_dependencies([optimizer.minimize(loss)]):
+                return i + 1
+
+        loop = tf.while_loop(lambda i: i < self.ITERATIONS * self.EPOCHS, loop_body, (0,))
+
+        # return model parameters after training
+        loop = tf.Print(loop, [], message="Training complete")
+        with tf.control_dependencies([loop]):
+            return [param.read_value() for param in params]
+
+    def provide_input(self) -> List[tf.Tensor]:
+        with tf.name_scope('loading'):
+            training_data = self.build_data_pipeline()
+
+        with tf.name_scope('training'):
+            parameters = self.build_training_graph(training_data)
+
+        return parameters
+
+
+class PredictionClient(tfe.io.InputProvider, tfe.io.OutputReceiver):
+
+    BATCH_SIZE = 20
+
+    def build_data_pipeline(self):
+
+        def normalize(image, label):
+            x = tf.cast(image, tf.float32) / 255.
+            image = (x - 0.1307) / 0.3081  # image = (x - mean) / std
+            return image, label
+
+        dataset = tf.data.TFRecordDataset(["./data/test.tfrecord"])
+        dataset = dataset.map(decode)
+        dataset = dataset.map(normalize)
+        dataset = dataset.batch(self.BATCH_SIZE)
+
+        iterator = dataset.make_one_shot_iterator()
+        return iterator
+
+    def provide_input(self) -> List[tf.Tensor]:
+        with tf.name_scope('loading'):
+            prediction_input, expected_result = self.build_data_pipeline().get_next()
+            prediction_input = tf.Print(prediction_input, [expected_result], summarize=self.BATCH_SIZE, message="EXPECT ")
+
+        with tf.name_scope('pre-processing'):
+            prediction_input = tf.reshape(prediction_input, shape=(self.BATCH_SIZE, 1, 28, 28))
+
+        return [prediction_input]
+
+    def receive_output(self, tensors: List[tf.Tensor]) -> tf.Operation:
+        likelihoods, = tensors
+        with tf.name_scope('post-processing'):
+            prediction = tf.argmax(likelihoods, axis=1)
+            op = tf.Print([], [prediction], summarize=self.BATCH_SIZE, message="ACTUAL ")
+            return op
+
+
+model_trainer = ModelTrainer(config.get_player('model-trainer'))
+prediction_client = PredictionClient(config.get_player('prediction-client'))
+
+server0 = config.get_player('server0')
+server1 = config.get_player('server1')
+crypto_producer = config.get_player('crypto-producer')
+
+with tfe.protocol.Pond(server0, server1, crypto_producer) as prot:
+
+    # get model parameters as private tensors from model owner
+    params = prot.define_private_input(model_trainer, masked=True)  # pylint: disable=E0632
+
+    # we'll use the same parameters for each prediction so we cache them to avoid re-training each time
+    params = prot.cache(params)
+
+    # get prediction input from client
+    x, = prot.define_private_input(prediction_client, masked=True)  # pylint: disable=E0632
+
+    # helpers
+    conv = lambda x, w: prot.conv2d(x, w, ModelTrainer.STRIDE, 'VALID')
+    pool = lambda x: prot.avgpool2d(x, (2, 2), (2, 2), 'VALID')
+
+    # compute prediction
+    Wconv1, bconv1, Wconv2, bconv2, Wfc1, bfc1, Wfc2, bfc2, Wfc3, bfc3 = params
+    bconv1 = prot.reshape(bconv1, [-1, 1, 1])
+    bconv2 = prot.reshape(bconv2, [-1, 1, 1])
+    layer1 = pool(prot.relu(conv(x, Wconv1) + bconv1))
+    layer2 = pool(prot.relu(conv(layer1, Wconv2) + bconv2))
+    layer2 = prot.reshape(layer2, [-1, ModelTrainer.HIDDEN_FC1])
+    layer3 = prot.dot(layer2, Wfc1) + bfc1
+    layer4 = prot.dot(layer3, Wfc2) + bfc2
+    logits = prot.dot(layer4, Wfc3) + bfc3
+
+    # send prediction output back to client
+    prediction_op = prot.define_output([logits], prediction_client)
+
+
+with config.session() as sess:
+    print("Init")
+    tfe.run(sess, tf.global_variables_initializer(), tag='init')
+
+    print("Training")
+    tfe.run(sess, tfe.global_caches_updator(), tag='training')
+
+    for _ in range(5):
+        print("Predicting")
+        tfe.run(sess, prediction_op, tag='prediction')

--- a/examples/securenn/network_d.py
+++ b/examples/securenn/network_d.py
@@ -1,0 +1,210 @@
+from __future__ import absolute_import
+import sys
+from typing import List
+import math
+
+import tensorflow as tf
+import tensorflow_encrypted as tfe
+
+from examples.securenn.conv_convert import decode
+
+
+if len(sys.argv) >= 2:
+    # config file was specified
+    config_file = sys.argv[1]
+    config = tfe.config.load(config_file)
+else:
+    # default to using local config
+    config = tfe.LocalConfig([
+        'server0',
+        'server1',
+        'crypto-producer',
+        'model-trainer',
+        'prediction-client'
+    ])
+
+
+def weight_variable(shape, gain):
+    """weight_variable generates a weight variable of a given shape."""
+    if len(shape) == 2:
+        fan_in, fan_out = shape
+    elif len(shape) == 4:
+        h, w, c_in, c_out = shape
+        fan_in = h * w * c_in
+        fan_out = h * w * c_out
+    r = gain * math.sqrt(6 / (fan_in + fan_out))
+    initial = tf.random_uniform(shape, minval=-r, maxval=r)
+    return tf.Variable(initial)
+
+
+def bias_variable(shape):
+    """bias_variable generates a bias variable of a given shape."""
+    initial = tf.constant(0., shape=shape)
+    return tf.Variable(initial)
+
+
+conv2d = lambda x, w, s: tf.nn.conv2d(x, w, strides=[1, s, s, 1], padding='VALID')
+pooling = lambda x: tf.nn.avg_pool(x, [1, 2, 2, 1], [1, 2, 2, 1], 'VALID')
+
+
+class ModelTrainer(tfe.io.InputProvider):
+    BATCH_SIZE = 32
+    ITERATIONS = 60000 // BATCH_SIZE
+    EPOCHS = 15
+    IN_DIM = 28
+    KERNEL = 5
+    STRIDE = 2
+    IN_CHANNELS = 1
+    HIDDEN_CHANNELS = 5
+    HIDDEN_FC1 = 180
+    HIDDEN_FC2 = 100
+    OUT_N = 10
+
+    def build_data_pipeline(self):
+
+        def normalize(image, label):
+            x = tf.cast(image, tf.float32) / 255.
+            image = (x - 0.1307) / 0.3081  # image = (x - mean) / std
+            return image, label
+
+        dataset = tf.data.TFRecordDataset(["./data/train.tfrecord"])
+        dataset = dataset.map(decode)
+        dataset = dataset.map(normalize)
+        dataset = dataset.repeat()
+        dataset = dataset.batch(self.BATCH_SIZE)
+
+        iterator = dataset.make_one_shot_iterator()
+        return iterator
+
+    def build_training_graph(self, training_data) -> List[tf.Tensor]:
+
+        # model parameters and initial values
+        Wconv1 = weight_variable([self.KERNEL,
+                                  self.KERNEL,
+                                  self.IN_CHANNELS,
+                                  self.HIDDEN_CHANNELS], 1.)
+        bconv1 = bias_variable([1, 1, self.HIDDEN_CHANNELS])
+        Wfc1 = weight_variable([self.HIDDEN_FC1, self.HIDDEN_FC2], 1.)
+        bfc1 = bias_variable([self.HIDDEN_FC2])
+        Wfc2 = weight_variable([self.HIDDEN_FC2, self.OUT_N], 1.)
+        bfc2 = bias_variable([self.OUT_N])
+        params = [Wconv1, bconv1, Wfc1, bfc1, Wfc2, bfc2]
+
+        # optimizer and data pipeline
+        optimizer = tf.train.AdamOptimizer(learning_rate=0.01)
+
+        # training loop
+        def loop_body(i):
+
+            # get next batch
+            x, y = training_data.get_next()
+
+            # model construction
+            x = tf.reshape(x, [-1, self.IN_DIM, self.IN_DIM, 1])
+            layer1 = pooling(tf.nn.relu(conv2d(x, Wconv1, self.STRIDE) + bconv1))
+            layer1 = tf.reshape(layer1, [-1, self.HIDDEN_FC1])
+            layer2 = tf.nn.relu(tf.matmul(layer1, Wfc1) + bfc1)
+            logits = tf.matmul(layer2, Wfc2) + bfc2
+
+            loss = tf.reduce_mean(tf.losses.sparse_softmax_cross_entropy(logits=logits, labels=y))
+            with tf.control_dependencies([optimizer.minimize(loss)]):
+                return i + 1
+
+        loop = tf.while_loop(lambda i: i < self.ITERATIONS * self.EPOCHS, loop_body, (0,))
+
+        # return model parameters after training
+        loop = tf.Print(loop, [], message="Training complete")
+        with tf.control_dependencies([loop]):
+            return [param.read_value() for param in params]
+
+    def provide_input(self) -> List[tf.Tensor]:
+        with tf.name_scope('loading'):
+            training_data = self.build_data_pipeline()
+
+        with tf.name_scope('training'):
+            parameters = self.build_training_graph(training_data)
+
+        return parameters
+
+
+class PredictionClient(tfe.io.InputProvider, tfe.io.OutputReceiver):
+
+    BATCH_SIZE = 20
+
+    def build_data_pipeline(self):
+
+        def normalize(image, label):
+            x = tf.cast(image, tf.float32) / 255.
+            image = (x - 0.1307) / 0.3081  # image = (x - mean) / std
+            return image, label
+
+        dataset = tf.data.TFRecordDataset(["./data/test.tfrecord"])
+        dataset = dataset.map(decode)
+        dataset = dataset.map(normalize)
+        dataset = dataset.batch(self.BATCH_SIZE)
+
+        iterator = dataset.make_one_shot_iterator()
+        return iterator
+
+    def provide_input(self) -> List[tf.Tensor]:
+        with tf.name_scope('loading'):
+            prediction_input, expected_result = self.build_data_pipeline().get_next()
+            prediction_input = tf.Print(prediction_input, [expected_result], summarize=self.BATCH_SIZE, message="EXPECT ")
+
+        with tf.name_scope('pre-processing'):
+            prediction_input = tf.reshape(prediction_input, shape=(self.BATCH_SIZE, 1, 28, 28))
+
+        return [prediction_input]
+
+    def receive_output(self, tensors: List[tf.Tensor]) -> tf.Operation:
+        likelihoods, = tensors
+        with tf.name_scope('post-processing'):
+            prediction = tf.argmax(likelihoods, axis=1)
+            op = tf.Print([], [prediction], summarize=self.BATCH_SIZE, message="ACTUAL ")
+            return op
+
+
+model_trainer = ModelTrainer(config.get_player('model-trainer'))
+prediction_client = PredictionClient(config.get_player('prediction-client'))
+
+server0 = config.get_player('server0')
+server1 = config.get_player('server1')
+crypto_producer = config.get_player('crypto-producer')
+
+with tfe.protocol.Pond(server0, server1, crypto_producer) as prot:
+
+    # get model parameters as private tensors from model owner
+    params = prot.define_private_input(model_trainer, masked=True)  # pylint: disable=E0632
+
+    # we'll use the same parameters for each prediction so we cache them to avoid re-training each time
+    params = prot.cache(params)
+
+    # get prediction input from client
+    x, = prot.define_private_input(prediction_client, masked=True)  # pylint: disable=E0632
+
+    # helpers
+    conv = lambda x, w, s: prot.conv2d(x, w, s, 'VALID')
+    pool = lambda x: prot.avgpool2d(x, (2, 2), (2, 2), 'VALID')
+
+    # compute prediction
+    Wconv1, bconv1, Wfc1, bfc1, Wfc2, bfc2 = params
+    bconv1 = prot.reshape(bconv1, [-1, 1, 1])
+    layer1 = pool(prot.relu(conv(x, Wconv1, ModelTrainer.STRIDE) + bconv1))
+    layer1 = prot.reshape(layer1, [-1, ModelTrainer.HIDDEN_FC1])
+    layer2 = prot.dot(layer1, Wfc1) + bfc1
+    logits = prot.dot(layer2, Wfc2) + bfc2
+
+    # send prediction output back to client
+    prediction_op = prot.define_output([logits], prediction_client)
+
+
+with config.session() as sess:
+    print("Init")
+    tfe.run(sess, tf.global_variables_initializer(), tag='init')
+
+    print("Training")
+    tfe.run(sess, tfe.global_caches_updator(), tag='training')
+
+    for _ in range(5):
+        print("Predicting")
+        tfe.run(sess, prediction_op, tag='prediction')


### PR DESCRIPTION
Contains each of the models A, B, C, D from the SecureNN experiments at `examples/securenn/network_*.py`.  Most are based on the previous code from `examples/securenn/network_a.py`, updated to conform to best practices for weight initialization.  Waiting on #136 to confirm that the models train to expected accuracies in plaintext.

Current secure predictions are quite poor, suggesting either (1) a flaw in the original plaintext training code, (2) significant relu approximation errors, or (3) a bug in the pond operations.

My bet is on (2,) but maybe also (3) 😄