### PR TITLE
Hack: logreg training example

### DIFF
--- a/examples/logreg/data.py
+++ b/examples/logreg/data.py
@@ -1,0 +1,38 @@
+from typing import Tuple
+
+import numpy as np
+import tensorflow as tf
+
+
+def norm(x: tf.Tensor, y: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
+    return tf.cast(x, tf.float32), tf.expand_dims(y, 0)
+
+
+def gen_training_input(total_size: int, nb_feats: int, bs: int) -> Tuple[tf.Tensor, tf.Tensor]:
+    x_np = np.random.uniform(-.5, .5, size=[total_size, nb_feats])
+    y_np = np.array(x_np.mean(axis=1) > 0, np.float32)
+    train_set = tf.data.Dataset.from_tensor_slices((x_np, y_np)) \
+                               .map(norm) \
+                               .shuffle(buffer_size=100) \
+                               .repeat() \
+                               .batch(bs)
+    train_set_iterator = train_set.make_one_shot_iterator()
+    x, y = train_set_iterator.get_next()
+    x = tf.reshape(x, [bs, nb_feats])
+    y = tf.reshape(y, [bs, 1])
+
+    return x, y
+
+
+def gen_test_input(total_size: int, nb_feats: int, bs: int) -> Tuple[tf.Tensor, tf.Tensor, np.ndarray]:
+    x_test_np = np.random.uniform(-.5, .5, size=[total_size, nb_feats])
+    y_test_np = np.array(x_test_np.mean(axis=1) > 0, np.float32)
+    test_set = tf.data.Dataset.from_tensor_slices((x_test_np, y_test_np)) \
+                              .map(norm) \
+                              .batch(bs)
+    test_set_iterator = test_set.make_one_shot_iterator()
+    x_test, y_test = test_set_iterator.get_next()
+    x_test = tf.reshape(x_test, [bs, nb_feats])
+    y_test = tf.reshape(y_test, [bs, 1])
+
+    return x_test, y_test, y_test_np

--- a/examples/logreg/tf-logreg.py
+++ b/examples/logreg/tf-logreg.py
@@ -1,43 +1,18 @@
-from typing import Tuple
-
-import numpy as np
 import tensorflow as tf
 
+from data import gen_training_input, gen_test_input
 
 # Parameters
-learning_rate = 0.001
+learning_rate = 0.01
+training_set_size = 1000
+test_set_size = 100
 training_epochs = 10
-train_batch_size = 100
-test_batch_size = 100
+batch_size = 100
 nb_feats = 5
 
 
-def norm(x: tf.Tensor, y: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
-    return tf.cast(x, tf.float32), tf.expand_dims(y, 0)
-
-
-x_np = np.random.uniform(-1 / 2, 1 / 2, size=[10000, nb_feats])
-y_np = np.array(x_np.mean(axis=1) > 0, np.float32)
-train_set = tf.data.Dataset.from_tensor_slices((x_np, y_np)) \
-                           .map(norm) \
-                           .shuffle(buffer_size=100) \
-                           .repeat() \
-                           .batch(train_batch_size)
-train_set_iterator = train_set.make_one_shot_iterator()
-x, y = train_set_iterator.get_next()
-x = tf.reshape(x, [train_batch_size, nb_feats])
-y = tf.reshape(y, [train_batch_size, 1])
-
-
-x_test_np = np.random.uniform(-1 / 2, 1 / 2, size=[100, nb_feats])
-y_test_np = np.array(x_test_np.mean(axis=1) > 0, np.float32)
-test_set = tf.data.Dataset.from_tensor_slices((x_test_np, y_test_np)) \
-                          .map(norm) \
-                          .batch(test_batch_size)
-test_set_iterator = test_set.make_one_shot_iterator()
-x_test, y_test = test_set_iterator.get_next()
-x_test = tf.reshape(x_test, [train_batch_size, nb_feats])
-y_test = tf.reshape(y_test, [train_batch_size, 1])
+x, y = gen_training_input(training_set_size, nb_feats, batch_size)
+x_test, y_test, _ = gen_test_input(test_set_size, nb_feats, batch_size)
 
 
 W = tf.Variable(tf.random_uniform([nb_feats, 1], -0.01, 0.01))
@@ -72,7 +47,7 @@ accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
 
 
 # Start training
-total_batch = int(len(x_np) / train_batch_size)
+total_batch = training_set_size // batch_size
 with tf.Session() as sess:
     sess.run(tf.global_variables_initializer())
 

--- a/examples/logreg/tf-logreg.py
+++ b/examples/logreg/tf-logreg.py
@@ -4,7 +4,6 @@ import numpy as np
 import tensorflow as tf
 
 
-
 # Parameters
 learning_rate = 0.001
 training_epochs = 10
@@ -12,10 +11,12 @@ train_batch_size = 100
 test_batch_size = 100
 nb_feats = 5
 
+
 def norm(x: tf.Tensor, y: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
     return tf.cast(x, tf.float32), tf.expand_dims(y, 0)
 
-x_np = np.random.uniform(-1/2, 1/2, size=[10000, nb_feats])
+
+x_np = np.random.uniform(-1 / 2, 1 / 2, size=[10000, nb_feats])
 y_np = np.array(x_np.mean(axis=1) > 0, np.float32)
 train_set = tf.data.Dataset.from_tensor_slices((x_np, y_np)) \
                            .map(norm) \
@@ -27,7 +28,8 @@ x, y = train_set_iterator.get_next()
 x = tf.reshape(x, [train_batch_size, nb_feats])
 y = tf.reshape(y, [train_batch_size, 1])
 
-x_test_np = np.random.uniform(-1/2, 1/2, size=[100, nb_feats])
+
+x_test_np = np.random.uniform(-1 / 2, 1 / 2, size=[100, nb_feats])
 y_test_np = np.array(x_test_np.mean(axis=1) > 0, np.float32)
 test_set = tf.data.Dataset.from_tensor_slices((x_test_np, y_test_np)) \
                           .map(norm) \
@@ -41,26 +43,33 @@ y_test = tf.reshape(y_test, [train_batch_size, 1])
 W = tf.Variable(tf.random_uniform([nb_feats, 1], -0.01, 0.01))
 b = tf.Variable(tf.zeros([1]))
 
+
 # Training model
 out = tf.matmul(x, W) + b
 pred = tf.sigmoid(out)
 cost = -tf.reduce_mean(y * tf.log(pred) + (1 - y) * tf.log(1 - pred))
 
+
 # Backprop
 # optimizer = tf.train.GradientDescentOptimizer(learning_rate).minimize(cost)
-
-dout = pred - y
-dW = tf.matmul(tf.transpose(x), dout)
-db = tf.reduce_sum(1. * dout, axis=0)
+# equivalent to:
+# dc_pred = - y / pred + (1 - y) / (1 - pred)
+# dc_out = pred * (1 - pred) * dc_pred
+# equivalent to:
+dc_out = pred - y
+dW = tf.matmul(tf.transpose(x), dc_out)
+db = tf.reduce_sum(1. * dc_out, axis=0)
 ops = [
     tf.assign(W, W - dW * learning_rate),
     tf.assign(b, b - db * learning_rate)
 ]
 
+
 # Testing model
 pred_test = tf.sigmoid(tf.matmul(x_test, W) + b)
 correct_prediction = tf.equal(tf.round(pred_test), y_test)
 accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
+
 
 # Start training
 total_batch = int(len(x_np) / train_batch_size)
@@ -74,7 +83,7 @@ with tf.Session() as sess:
             _, c = sess.run([ops, cost])
             avg_cost += c / total_batch
 
-        print("Epoch:", '%04d' % (epoch+1), "cost=", "{:.9f}".format(avg_cost))
+        print("Epoch:", '%04d' % (epoch + 1), "cost=", "{:.9f}".format(avg_cost))
 
     print("Optimization Finished!")
 

--- a/examples/logreg/tf-logreg.py
+++ b/examples/logreg/tf-logreg.py
@@ -1,0 +1,81 @@
+from typing import Tuple
+
+import numpy as np
+import tensorflow as tf
+
+
+
+# Parameters
+learning_rate = 0.001
+training_epochs = 10
+train_batch_size = 100
+test_batch_size = 100
+nb_feats = 5
+
+def norm(x: tf.Tensor, y: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
+    return tf.cast(x, tf.float32), tf.expand_dims(y, 0)
+
+x_np = np.random.uniform(-1/2, 1/2, size=[10000, nb_feats])
+y_np = np.array(x_np.mean(axis=1) > 0, np.float32)
+train_set = tf.data.Dataset.from_tensor_slices((x_np, y_np)) \
+                           .map(norm) \
+                           .shuffle(buffer_size=100) \
+                           .repeat() \
+                           .batch(train_batch_size)
+train_set_iterator = train_set.make_one_shot_iterator()
+x, y = train_set_iterator.get_next()
+x = tf.reshape(x, [train_batch_size, nb_feats])
+y = tf.reshape(y, [train_batch_size, 1])
+
+x_test_np = np.random.uniform(-1/2, 1/2, size=[100, nb_feats])
+y_test_np = np.array(x_test_np.mean(axis=1) > 0, np.float32)
+test_set = tf.data.Dataset.from_tensor_slices((x_test_np, y_test_np)) \
+                          .map(norm) \
+                          .batch(test_batch_size)
+test_set_iterator = test_set.make_one_shot_iterator()
+x_test, y_test = test_set_iterator.get_next()
+x_test = tf.reshape(x_test, [train_batch_size, nb_feats])
+y_test = tf.reshape(y_test, [train_batch_size, 1])
+
+
+W = tf.Variable(tf.random_uniform([nb_feats, 1], -0.01, 0.01))
+b = tf.Variable(tf.zeros([1]))
+
+# Training model
+out = tf.matmul(x, W) + b
+pred = tf.sigmoid(out)
+cost = -tf.reduce_mean(y * tf.log(pred) + (1 - y) * tf.log(1 - pred))
+
+# Backprop
+# optimizer = tf.train.GradientDescentOptimizer(learning_rate).minimize(cost)
+
+dout = pred - y
+dW = tf.matmul(tf.transpose(x), dout)
+db = tf.reduce_sum(1. * dout, axis=0)
+ops = [
+    tf.assign(W, W - dW * learning_rate),
+    tf.assign(b, b - db * learning_rate)
+]
+
+# Testing model
+pred_test = tf.sigmoid(tf.matmul(x_test, W) + b)
+correct_prediction = tf.equal(tf.round(pred_test), y_test)
+accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
+
+# Start training
+total_batch = int(len(x_np) / train_batch_size)
+with tf.Session() as sess:
+    sess.run(tf.global_variables_initializer())
+
+    for epoch in range(training_epochs):
+        avg_cost = 0.
+
+        for i in range(total_batch):
+            _, c = sess.run([ops, cost])
+            avg_cost += c / total_batch
+
+        print("Epoch:", '%04d' % (epoch+1), "cost=", "{:.9f}".format(avg_cost))
+
+    print("Optimization Finished!")
+
+    print("Accuracy:", accuracy.eval())

--- a/examples/logreg/tfe-logreg.py
+++ b/examples/logreg/tfe-logreg.py
@@ -1,0 +1,106 @@
+from typing import Tuple, Union
+
+import numpy as np
+import tensorflow as tf
+import tensorflow_encrypted as tfe
+from tensorflow_encrypted.protocol.pond import PondPrivateTensor
+
+config = tfe.LocalConfig([
+    'server0',
+    'server1',
+    'crypto_producer'
+])
+server0 = config.get_player('server0')
+server1 = config.get_player('server1')
+crypto_producer = config.get_player('crypto_producer')
+
+def consume(v: Union[np.ndarray, tf.Tensor], prot: tfe.protocol.Pond) -> PondPrivateTensor:
+    val = tfe.protocol.pond._encode(v, True)
+    x0, x1 = tfe.protocol.pond._share(val)
+    x = PondPrivateTensor(prot, x0, x1, True)
+    return x
+
+# Parameters
+learning_rate = 0.001
+training_epochs = 10
+train_batch_size = 100
+test_batch_size = 100
+nb_feats = 5
+
+def norm(x: tf.Tensor, y: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
+    return tf.cast(x, tf.float32), tf.expand_dims(y, 0)
+
+x_np = np.random.uniform(-1/2, 1/2, size=[10000, nb_feats])
+y_np = np.array(x_np.mean(axis=1) > 0, np.float32)
+train_set = tf.data.Dataset.from_tensor_slices((x_np, y_np)) \
+                           .map(norm) \
+                           .shuffle(buffer_size=100) \
+                           .repeat() \
+                           .batch(train_batch_size)
+train_set_iterator = train_set.make_one_shot_iterator()
+x, y = train_set_iterator.get_next()
+x = tf.reshape(x, [train_batch_size, nb_feats])
+y = tf.reshape(y, [train_batch_size, 1])
+
+x_test_np = np.random.uniform(-1/2, 1/2, size=[100, nb_feats])
+y_test_np = np.array(x_test_np.mean(axis=1) > 0, np.float32)
+test_set = tf.data.Dataset.from_tensor_slices((x_test_np, y_test_np)) \
+                          .map(norm) \
+                          .batch(test_batch_size)
+test_set_iterator = test_set.make_one_shot_iterator()
+x_test, y_test = test_set_iterator.get_next()
+x_test = tf.reshape(x_test, [train_batch_size, nb_feats])
+y_test = tf.reshape(y_test, [train_batch_size, 1])
+
+with tfe.protocol.Pond(server0, server1, crypto_producer) as prot:
+    assert(isinstance(prot, tfe.protocol.Pond))
+
+    W = prot.define_private_variable(tf.random_uniform([nb_feats, 1], -0.01, 0.01))
+    b = prot.define_private_variable(tf.zeros([1]))
+    xp = consume(x, prot) # We secure our inputs
+    yp = consume(y, prot)
+
+    # Training model
+    out = prot.dot(xp, W) + b
+    pred = prot.sigmoid(out)
+    # Due to missing log function approximation, we need to compute the cost in numpy
+    # cost = -prot.sum(y * prot.log(pred) + (1 - y) * prot.log(1 - pred)) * (1/train_batch_size)
+
+    # Backprop
+    dout = pred - yp
+    dW = prot.dot(prot.transpose(xp), dout) # [nb_feats, 1] <- [nb_feats, bs].[bs, 1]
+    db = prot.sum(dout * 1.0, axis=0, keepdims=False)
+    ops = [
+        prot.assign(W, W - dW * learning_rate),
+        prot.assign(b, b - db * learning_rate)
+    ]
+
+    # Testing model
+    xp_test = consume(x_test, prot) # We secure our inputs
+    yp_test = consume(y_test, prot)
+    pred_test = prot.sigmoid(prot.dot(xp_test, W) + b)
+
+    total_batch = int(len(x_np) / train_batch_size)
+    with config.session() as sess:
+        tfe.run(sess, prot.initializer, tag='init')
+
+        for epoch in range(training_epochs):
+            avg_cost = 0.
+
+            for i in range(total_batch):
+                p_out = pred.reveal().eval(sess)
+                _, y_out = tfe.run(sess, [ops, y], tag='optimize')
+                # Our sigmoid function is an approximation
+                # it can have values outside of the range [0, 1], we remove them and add/substract an epsilon to compute the cost
+                p_out = p_out * (p_out > 0) + 0.001
+                p_out = p_out * (p_out < 1) + (p_out >= 1) * 0.999
+                c = -np.mean(y_out * np.log(p_out) + (1 - y_out) * np.log(1 - p_out))
+                avg_cost += c / total_batch
+
+            print("Epoch:", '%04d' % (epoch+1), "cost=", "{:.9f}".format(avg_cost))
+
+        print("Optimization Finished!")
+
+        out_test = pred_test.reveal().eval(sess)
+        acc = np.mean(np.round(out_test) == y_test_np)
+        print("Accuracy:", acc)

--- a/stubs/tensorflow/__init__.pyi
+++ b/stubs/tensorflow/__init__.pyi
@@ -497,8 +497,8 @@ def constant(
 
 
 def matmul(
-    a: Union[np.ndarray, Tensor],
-    b: Union[np.ndarray, Tensor],
+    a: Union[np.ndarray, Tensor, Variable],
+    b: Union[np.ndarray, Tensor, Variable],
     transpose_a=False,
     transpose_b=False,
     adjoint_a=False,
@@ -511,11 +511,19 @@ def matmul(
 
 
 def random_uniform(
-    shape: Union[Tuple[int, ...], TensorShape],
+    shape: Union[List[int], Tuple[int, ...], TensorShape],
     minval: Any = 0,
     maxval: Optional[Any] = None,
     dtype: Optional[TFTypes] = float32,
     seed: Optional[int] = None,
+    name: Optional[str] = None
+) -> Tensor:
+    ...
+
+
+def zeros(
+    shape: Union[List[int], Tuple[int, ...], TensorShape],
+    dtype: Optional[TFTypes] = float32,
     name: Optional[str] = None
 ) -> Tensor:
     ...
@@ -544,5 +552,22 @@ def stack(
     values: List[Union[np.ndarray, Tensor]],
     axis: int=0,
     name: str='stack'
+) -> Tensor:
+    ...
+
+
+def cast(
+    x: Union[np.ndarray, Tensor],
+    dtype: Optional[TFTypes] = float32,
+    name: Optional[str] = None
+) -> Tensor:
+    ...
+
+
+def expand_dims(
+    input: Tensor,
+    axis: int=0,
+    name: Optional[str] = None,
+    dim: Optional[int] = None
 ) -> Tensor:
     ...

--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -882,6 +882,9 @@ class PondTensor(abc.ABC):
     def __mul__(self, other):
         return self.prot.mul(self, other)
 
+    def __rmul__(self, other):
+        return self.prot.mul(self, other)
+
     def square(self):
         return self.prot.square(self)
 

--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -24,7 +24,7 @@ from .protocol import Protocol, global_cache_updators, memoize, nodes
 TFEData = Union[np.ndarray, tf.Tensor]
 TFEVariable = Union['PondPublicVariable', 'PondPrivateVariable', tf.Variable]
 TFEPublicTensor = NewType('TFEPublicTensor', 'PondPublicTensor')
-TFETensor = Union[TFEPublicTensor, 'PondPrivateTensor']
+TFETensor = Union[TFEPublicTensor, 'PondPrivateTensor', 'PondMaskedTensor']
 
 # the assumption in encoding/decoding is that encoded numbers will fit into signed int32
 BITPRECISION_INTEGRAL = 14
@@ -474,7 +474,7 @@ class Pond(Protocol):
         return self.dispatch('square', x)
 
     @memoize
-    def dot(self, x, y):
+    def dot(self, x: 'PondTensor', y: 'PondTensor') -> 'PondTensor':
         return self.dispatch('dot', x, y)
 
     @memoize
@@ -1188,7 +1188,6 @@ class PondCachedMaskedTensor(PondMaskedTensor):
 
     def __repr__(self) -> str:
         return 'PondCachedMaskedTensor(shape={})'.format(self.shape)
-
 
 #
 # helpers


### PR DESCRIPTION
close #152 

Note: Backprop is not working (the model is not training at all). I can't find any obvious error in my implementation so I think it's probably due to sigmoid approximation. 
More on this below:

The working TF code for the derivative looks like this:
```python
# Training model
out = tf.matmul(x, W) + b
pred = tf.sigmoid(out)

# Backprop
# dc_pred = - y / pred + (1 - y) / (1 - pred)
# dc_out = pred * (1 - pred) * dc_pred
# equivalent to:
dc_out = pred - y
```

So currently I apply the derivative equivalent in the encrypted setup:
```python
# Training model
out = prot.dot(xp, W) + b
pred = prot.sigmoid(out)

# Backprop
dc_out = pred - yp
```

Now, the thing is that this simplification is not true and probably too much off with our current approximation. 
Also even if I compute the real polynomial derivative to get `dc_out` from `dc_pred`, we need to divide by a private tensor (`pred`) to get `dc_pred` which is not yet possible.

What do you think? @jvmancuso @mortendahl 