### PR TITLE
int 32 binarize

### DIFF
--- a/tensorflow_encrypted/tensor/int32.py
+++ b/tensorflow_encrypted/tensor/int32.py
@@ -116,13 +116,12 @@ class Int32Tensor(AbstractTensor):
         return Int32Tensor.from_native(tf.concat(backing, axis=axis))
 
     def binarize(self) -> NativeTensor:
-        """Computes bit decomposition of tensor
-         tensor: ndarray of shape (x0, ..., xn)
-        returns: a binary tensor of shape (x0, ..., xn, bits) equivalent to tensor
-        """
         bitwidths = tf.range(bits, dtype=tf.int32)
-        for i in range(len(self.shape)):
-            bitwidths = tf.expand_dims(bitwidths, 0)
+
+        final_shape = [1] * len(self.shape)
+        final_shape.append(bits)
+
+        bitwidths = tf.reshape(bitwidths, final_shape)
         val = tf.expand_dims(self.value, -1)
         val = tf.bitwise.bitwise_and(tf.bitwise.right_shift(val, bitwidths), 1)
 

--- a/tensorflow_encrypted/tensor/int32.py
+++ b/tensorflow_encrypted/tensor/int32.py
@@ -5,8 +5,12 @@ import tensorflow as tf
 from typing import Union, Optional, List, Dict, Any, Tuple, Type
 from .tensor import AbstractTensor, AbstractVariable, AbstractConstant, AbstractPlaceholder
 from .factory import AbstractFactory
+from .native import NativeTensor
 
 from ..config import run
+
+bits = 31
+p = 67
 
 
 class Int32Tensor(AbstractTensor):
@@ -110,6 +114,19 @@ class Int32Tensor(AbstractTensor):
         backing = [v.value for v in x]
 
         return Int32Tensor.from_native(tf.concat(backing, axis=axis))
+
+    def binarize(self) -> NativeTensor:
+        """Computes bit decomposition of tensor
+         tensor: ndarray of shape (x0, ..., xn)
+        returns: a binary tensor of shape (x0, ..., xn, bits) equivalent to tensor
+        """
+        bitwidths = tf.range(bits, dtype=tf.int32)
+        for i in range(len(self.shape)):
+            bitwidths = tf.expand_dims(bitwidths, 0)
+        val = tf.expand_dims(self.value, -1)
+        val = tf.bitwise.bitwise_and(tf.bitwise.right_shift(val, bitwidths), 1)
+
+        return NativeTensor.from_native(val, p)
 
 
 def _lift(x: Union[Int32Tensor, int]) -> Int32Tensor:

--- a/tensorflow_encrypted/tensor/native.py
+++ b/tensorflow_encrypted/tensor/native.py
@@ -162,13 +162,13 @@ class NativeTensor(AbstractTensor):
         return NativeTensor(tf.reshape(self.value, axes), self.modulus)
 
     def binarize(self) -> 'NativeTensor':
-        """Computes bit decomposition of tensor
-         tensor: ndarray of shape (x0, ..., xn)
-        returns: a binary tensor of shape (x0, ..., xn, bits) equivalent to tensor
-        """
         bitwidths = tf.range(bits, dtype=INT_TYPE)
-        for i in range(len(self.shape)):
-            bitwidths = tf.expand_dims(bitwidths, 0)
+
+        final_shape = [1] * len(self.shape)
+        final_shape.append(bits)
+
+        bitwidths = tf.reshape(bitwidths, final_shape)
+
         val = tf.expand_dims(self.value, -1)
         val = tf.bitwise.bitwise_and(tf.bitwise.right_shift(val, bitwidths), 1)
 

--- a/tests/test_int32_tensor.py
+++ b/tests/test_int32_tensor.py
@@ -7,6 +7,9 @@ from tensorflow_encrypted.tensor.int32 import Int32Factory, Int32Tensor
 
 
 class TestInt32Tensor(unittest.TestCase):
+    def setUp(self):
+        tf.reset_default_graph()
+
     def test_pond(self) -> None:
         config = tfe.LocalConfig([
             'server0',
@@ -39,6 +42,22 @@ class TestInt32Tensor(unittest.TestCase):
             actual = sess.run(y.value)
 
         np.testing.assert_array_equal(actual, expected)
+
+    def test_random_binarize(self) -> None:
+        input = np.random.uniform(high=2**31 - 1, size=2000).astype('int32').tolist()
+        x = Int32Tensor(tf.constant(input, dtype=tf.int32))
+
+        y = x.binarize()
+
+        with tf.Session() as sess:
+            actual = sess.run(y.value)
+
+        j = 0
+        for i in input:
+            binary = bin(i)[2:].zfill(32)[::-1][:31]
+            bin_list = np.array(list(binary)).astype('int32')
+            np.testing.assert_equal(actual[j], bin_list)
+            j += 1
 
 
 if __name__ == '__main__':

--- a/tests/test_int32_tensor.py
+++ b/tests/test_int32_tensor.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
-from tensorflow_encrypted.tensor.int32 import Int32Factory
+from tensorflow_encrypted.tensor.int32 import Int32Factory, Int32Tensor
 
 
 class TestInt32Tensor(unittest.TestCase):
@@ -26,6 +26,19 @@ class TestInt32Tensor(unittest.TestCase):
                 sess.run(tf.global_variables_initializer())
                 out = z.reveal().eval(sess)
                 np.testing.assert_array_almost_equal(out, [4, 4], decimal=3)
+
+    def test_binarize(self) -> None:
+        x = Int32Tensor(tf.constant([2**31 + 2**31 + 3, 3], dtype=np.int32))
+
+        y = x.binarize()
+
+        expected = [[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+
+        with tf.Session() as sess:
+            actual = sess.run(y.value)
+
+        np.testing.assert_array_equal(actual, expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_int32_tensor.py
+++ b/tests/test_int32_tensor.py
@@ -31,12 +31,16 @@ class TestInt32Tensor(unittest.TestCase):
                 np.testing.assert_array_almost_equal(out, [4, 4], decimal=3)
 
     def test_binarize(self) -> None:
-        x = Int32Tensor(tf.constant([2**31 + 2**31 + 3, 3], dtype=np.int32))
+        x = Int32Tensor(tf.constant([2**31 + 2**31 + 3, 3, 3, 3], shape=[2, 2], dtype=np.int32))
 
         y = x.binarize()
 
-        expected = [[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                    [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+        expected = np.array([[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                             [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                             [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                             [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
+
+        expected = np.reshape(expected, [2, 2, 31])
 
         with tf.Session() as sess:
             actual = sess.run(y.value)


### PR DESCRIPTION
Implements binarize for int32. Numbers of bits to generate and p are hardcoded right now. Might want to change that and binarize can take a p arg.