### PR TITLE
Python35

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cd tf-encrypted
 pip install -e .
 ```
 
-Note however that currently **only Python 3.6 is supported**; to manage this we recommend using a package manager like pip or conda.
+Note however that currently **only Python 3.5 and 3.6 are supported**; to manage this we recommend using a package manager like pip or conda.
 
 After successful installation you should be able to e.g. run the examples
 

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires=">=3.5",
     install_requires=[
-        "tensorflow>=1.10.0",
+        "tensorflow>=1.9.0",
         "numpy>=1.14.0"
     ],
     extra_requires={
-        "tf": ["tensorflow>=1.10.0"],
-        "tf_gpu": ["tensorflow-gpu>=1.10.0"]
+        "tf": ["tensorflow>=1.9.0"],
+        "tf_gpu": ["tensorflow-gpu>=1.9.0"]
     },
     license="Apache License 2.0",
     url="https://github.com/mortendahl/tf-encrypted",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setuptools.setup(
     name="tf-encrypted",
     version="0.1.0",
     packages=setuptools.find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.5",
     install_requires=[
         "tensorflow>=1.10.0",
         "numpy>=1.14.0"

--- a/tensorflow_encrypted/config.py
+++ b/tensorflow_encrypted/config.py
@@ -19,7 +19,7 @@ __TFE_STATS__ = bool(os.getenv('TFE_STATS', False))
 __TFE_TRACE__ = bool(os.getenv('TFE_TRACE', False))
 __TENSORBOARD_DIR__ = str(os.getenv('TFE_STATS_DIR', '/tmp/tensorboard'))
 
-_run_counter = defaultdict(int)
+_run_counter = defaultdict(int)  # type: Any
 
 
 class Config(ABC):

--- a/tensorflow_encrypted/config.py
+++ b/tensorflow_encrypted/config.py
@@ -19,7 +19,7 @@ __TFE_STATS__ = bool(os.getenv('TFE_STATS', False))
 __TFE_TRACE__ = bool(os.getenv('TFE_TRACE', False))
 __TENSORBOARD_DIR__ = str(os.getenv('TFE_STATS_DIR', '/tmp/tensorboard'))
 
-_run_counter: Any = defaultdict(int)
+_run_counter = defaultdict(int)
 
 
 class Config(ABC):

--- a/tensorflow_encrypted/convert/convert.py
+++ b/tensorflow_encrypted/convert/convert.py
@@ -10,7 +10,6 @@ from ..config import Config
 
 
 class ConvertInputProvider(InputProvider):
-    input: np.ndarray
 
     def __init__(self, player: Player, input: np.ndarray) -> None:
         self.input = input
@@ -21,16 +20,13 @@ class ConvertInputProvider(InputProvider):
 
 
 class Converter():
-    config: Config
-    protocol: Pond
-    outputs: Dict[str, Any] = {}
-    weights_provider: Player
 
     def __init__(self, config: Config, protocol: Pond,
                  weights_provider: Player) -> None:
         self.config = config
         self.protocol = protocol
         self.weights_provider = weights_provider
+        self.outputs = {}
 
     def convert(self, graph_def: Any, input: Union[List[InputProvider], InputProvider],
                 register: Dict[str, Any]) -> Any:
@@ -78,7 +74,7 @@ def extract_graph_summary(graph_def: Any) -> Tuple[Dict[str, List[str]],
     name_to_node = {}  # Keyed by node name.
 
     for node in graph_def.node:
-        name: str = node.name
+        name = node.name
         n = node_name(name)
         name_to_node[n] = node
         name_to_input_name[n] = [node_name(x) for x in node.input]

--- a/tensorflow_encrypted/layers/activation.py
+++ b/tensorflow_encrypted/layers/activation.py
@@ -23,6 +23,7 @@ class Sigmoid(core.Layer):
 
 
 class Relu(core.Layer):
+
     def get_output_shape(self) -> List[int]:
         return self.input_shape
 
@@ -40,6 +41,7 @@ class Relu(core.Layer):
 
 
 class Tanh(core.Layer):
+
     def get_output_shape(self) -> List[int]:
         return self.input_shape
 

--- a/tensorflow_encrypted/layers/batchnorm.py
+++ b/tensorflow_encrypted/layers/batchnorm.py
@@ -6,6 +6,7 @@ from tensorflow_encrypted.protocol.pond import PondPrivateTensor
 
 
 class Batchnorm(core.Layer):
+
     def __init__(self, input_shape: List[int],
                  mean: np.ndarray, variance: np.ndarray, scale: np.ndarray,
                  offset: np.ndarray, variance_epsilon: float = 1e-8) -> None:

--- a/tensorflow_encrypted/layers/convolution.py
+++ b/tensorflow_encrypted/layers/convolution.py
@@ -6,6 +6,7 @@ from . import core
 
 
 class Conv2D(core.Layer):
+
     def __init__(self,
                  input_shape: List[int], filter_shape: List[int],
                  strides: int = 1, padding: str = "SAME",

--- a/tensorflow_encrypted/layers/core.py
+++ b/tensorflow_encrypted/layers/core.py
@@ -9,13 +9,10 @@ from ..protocol.pond import TFEVariable
 
 
 class Layer(ABC):
-    input_shape: List[int]
-    output_shape: List[int]
 
     def __init__(self, input_shape: List[int]) -> None:
         self.input_shape = input_shape
         self.output_shape = self.get_output_shape()
-
         self.layer_output = None
 
     @abstractmethod

--- a/tensorflow_encrypted/layers/pooling.py
+++ b/tensorflow_encrypted/layers/pooling.py
@@ -49,8 +49,8 @@ class AveragePooling2D(core.Layer):
             _, H_in, W_in, channels = self.input_shape
 
         if self.padding == "SAME":
-            H_out: int = math.ceil(H_in / self.strides[0])
-            W_out: int = math.ceil(W_in / self.strides[1])
+            H_out = math.ceil(H_in / self.strides[0])
+            W_out = math.ceil(W_in / self.strides[1])
         else:
             H_out = math.ceil((H_in - self.pool_size[0] + 1) / self.strides[0])
             W_out = math.ceil((W_in - self.pool_size[1] + 1) / self.strides[1])

--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -34,7 +34,7 @@ BOUND = 2**30  # bound on magnitude of encoded numbers: x in [-BOUND, +BOUND)
 STATISTICAL_SECURITY = 40  # number of bit for statistical security TODO[Morten] write assertions
 
 
-_initializers: List = list()
+_initializers = list()
 _thismodule = sys.modules[__name__]
 
 
@@ -82,8 +82,7 @@ class Pond(Protocol):
             with tf.device(self.server_1.device_name):
                 x_on_1 = self.tensor_factory.Constant.from_same(v)
 
-        x = PondConstant(self, x_on_0, x_on_1, apply_scaling)
-        return x
+        return PondConstant(self, x_on_0, x_on_1, apply_scaling)
 
     def define_public_placeholder(self, shape, apply_scaling: bool = True, name: Optional[str] = None):
 
@@ -224,11 +223,9 @@ class Pond(Protocol):
     ) -> Union['PondPrivateTensor', 'PondMaskedTensor', List['PondPrivateTensor'], List['PondMaskedTensor']]:
 
         def helper(v: tf.Tensor):
-            assert v.shape.is_fully_defined(), "Shape of input '{}' on '{}' is not fully defined".format(
-                name if name else '', provider.player.name)
-
-            val = self._encode(v, apply_scaling)
-            x0, x1 = self._share(val)
+            assert v.shape.is_fully_defined(), "Shape of input '{}' on '{}' is not fully defined".format(name if name else '', provider.player.name)
+            w = self._encode(v, apply_scaling)
+            x0, x1 = self._share(w)
             x = PondPrivateTensor(self, x0, x1, apply_scaling)
 
             if not masked:
@@ -237,7 +234,7 @@ class Pond(Protocol):
                 with tf.name_scope('local_mask'):
                     a = self.tensor_factory.Tensor.sample_uniform(v.shape)
                     a0, a1 = self._share(a)
-                    alpha = val - a
+                    alpha = w - a
                 return PondMaskedTensor(self, x, a, a0, a1, alpha, alpha, apply_scaling)
 
         with tf.name_scope('private-input{}'.format('-' + name if name else '')):
@@ -271,9 +268,9 @@ class Pond(Protocol):
         def helper(x: 'PondPrivateTensor') -> tf.Tensor:
             assert isinstance(x, PondPrivateTensor), type(x)
             x0, x1 = x.unwrapped
-            v = self._reconstruct(x0, x1)
-            w: tf.Tensor = self._decode(v, x.is_scaled)
-            return w
+            w = self._reconstruct(x0, x1)
+            v = self._decode(w, x.is_scaled)
+            return v
 
         with tf.name_scope('output{}'.format('-' + name if name else '')):
 
@@ -325,8 +322,8 @@ class Pond(Protocol):
         with tf.name_scope('decode'):
             scaling_factor = 2 ** BITPRECISION_FRACTIONAL if is_scaled else 1
 
-        # NOTE we assume that x + BOUND fits within int32, ie that (BOUND - 1) + BOUND <= 2**31 - 1
-        return ((elements + BOUND).to_int32() - BOUND) / scaling_factor
+            # NOTE we assume that x + BOUND fits within int32, ie that (BOUND - 1) + BOUND <= 2**31 - 1
+            return ((elements + BOUND).to_int32() - BOUND) / scaling_factor
 
     def _share(self, secret: AbstractTensor) -> Tuple[AbstractTensor, AbstractTensor]:
         with tf.name_scope('share'):
@@ -338,16 +335,11 @@ class Pond(Protocol):
         with tf.name_scope('reconstruct'):
             return share0 + share1
 
+    @memoize
     def assign(self, variable, value):
         assert isinstance(variable, PondPrivateVariable), type(variable)
         assert isinstance(value, PondPrivateTensor), type(value)
         assert variable.is_scaled == value.is_scaled, "Scaling must match: {}, {}".format(variable.is_scaled, value.is_scaled)
-
-        node_key = ('assign', variable, value)
-        op = nodes.get(node_key, None)
-
-        if op is not None:
-            return op
 
         var0, var1 = variable.variable0, variable.variable1
         val0, val1 = value.share0, value.share1
@@ -360,8 +352,7 @@ class Pond(Protocol):
             with tf.device(self.server_1.device_name):
                 op1 = var1.assign_from_same(val1)
 
-        op = tf.group(op0, op1)
-        nodes[node_key] = op
+            op = tf.group(op0, op1)
 
         return op
 
@@ -415,13 +406,8 @@ class Pond(Protocol):
 
             raise TypeError("Don't know how to lift {}, {}".format(type(x), type(y)))
 
+    @memoize
     def sum(self, x, axis, keepdims):
-        node_key = ('sum', x)
-        z = nodes.get(node_key, None)
-
-        if z is not None:
-            return z
-
         x = self.lift(x)
 
         dispatch = {
@@ -433,10 +419,7 @@ class Pond(Protocol):
         if func is None:
             raise TypeError("Don't know how to sum {}".format(type(x)))
 
-        z = func(self, x, axis, keepdims)
-        nodes[node_key] = z
-
-        return z
+        return func(self, x, axis, keepdims)
 
     @memoize
     def sub(self, x, y):
@@ -508,80 +491,47 @@ class Pond(Protocol):
 
         return x_t
 
+    @memoize
     def reshape(self, x: 'PondTensor', shape: List[int]):
 
-        node_key = ('reshape', x)
-        x_reshaped = nodes.get(node_key, None)
-
-        if x_reshaped is not None:
-            return x_reshaped
-
         if isinstance(x, PondPublicTensor):
-            x_reshaped = _reshape_public(self, x, shape)
+            return _reshape_public(self, x, shape)
 
-        elif isinstance(x, PondPrivateTensor):
-            x_reshaped = _reshape_private(self, x, shape)
+        if isinstance(x, PondPrivateTensor):
+            return _reshape_private(self, x, shape)
 
-        elif isinstance(x, PondMaskedTensor):
-            x_reshaped = _reshape_masked(self, x, shape)
-            nodes[('reshape', x.unmasked)] = x_reshaped.unmasked
+        if isinstance(x, PondMaskedTensor):
+            return _reshape_masked(self, x, shape)
 
-        else:
-            raise TypeError("Don't know how to reshape {}".format(type(x)))
+        raise TypeError("Don't know how to reshape {}".format(type(x)))
 
-        nodes[node_key] = x_reshaped
-
-        return x_reshaped
-
+    @memoize
     def expand_dims(self, x: 'PondTensor', axis=None):
 
-        node_key = ('expand', x)
-        x_e = nodes.get(node_key, None)
-
-        if x_e is not None:
-            return x_e
-
         if isinstance(x, PondPublicTensor):
-            x_e = _expand_dims_public(self, x, axis=axis)
+            return _expand_dims_public(self, x, axis=axis)
 
-        elif isinstance(x, PondPrivateTensor):
-            x_e = _expand_dims_private(self, x, axis=axis)
+        if isinstance(x, PondPrivateTensor):
+            return _expand_dims_private(self, x, axis=axis)
 
-        elif isinstance(x, PondMaskedTensor):
-            x_e = _expand_dims_masked(self, x, axis=axis)
-            nodes[('expand', x.unmasked)] = x_e.unmasked
+        if isinstance(x, PondMaskedTensor):
+            return _expand_dims_masked(self, x, axis=axis)
 
-        else:
-            raise TypeError("Don't know how to expand dims {}".format(type(x)))
+        raise TypeError("Don't know how to expand dims {}".format(type(x)))
 
-        nodes[node_key] = x_e
-
-        return x_e
-
+    @memoize
     def squeeze(self, x: 'PondTensor', axis: Optional[List[int]]=None):
 
-        node_key = ('squeeze', x)
-        x_squeezed = nodes.get(node_key, None)
-
-        if x_squeezed is not None:
-            return x_squeezed
-
         if isinstance(x, PondPublicTensor):
-            x_squeezed = _squeeze_public(self, x, axis)
+            return _squeeze_public(self, x, axis)
 
-        elif isinstance(x, PondPrivateTensor):
-            x_squeezed = _squeeze_private(self, x, axis)
+        if isinstance(x, PondPrivateTensor):
+            return _squeeze_private(self, x, axis)
 
-        elif isinstance(x, PondMaskedTensor):
-            x_squeezed = _squeeze_masked(self, x, axis)
-            nodes[('sqeeze', x.unmasked)] = x_squeezed.unmasked
+        if isinstance(x, PondMaskedTensor):
+            return _squeeze_masked(self, x, axis)
 
-        else:
-            raise TypeError("Don't know how to squeeze {}".format(type(x)))
-
-        nodes[node_key] = x_squeezed
-
-        return x_squeezed
+        raise TypeError("Don't know how to squeeze {}".format(type(x)))
 
     def strided_slice(self, x: 'PondTensor', *args: Any, **kwargs: Any):
         """ See https://www.tensorflow.org/api_docs/python/tf/strided_slice for documentation on the arguments """
@@ -631,21 +581,18 @@ class Pond(Protocol):
         return xs_stack
 
     @memoize
-    def concat(self, xc: List['PondTensor'], axis):
-        xc_concat: Union[PondPublicTensor, PondPrivateTensor, PondMaskedTensor]
+    def concat(self, xs: List['PondTensor'], axis):
 
-        if all([isinstance(x, PondPublicTensor) for x in xc]):
-            xc_concat = _concat_shared(self, xc, axis=axis)
+        if all(isinstance(x, PondPublicTensor) for x in xs):
+            return _concat_public(self, xs, axis=axis)
 
-        elif all([isinstance(x, PondPrivateTensor) for x in xc]):
-            xc_concat = _concat_shared(self, xc, axis=axis)
+        if all(isinstance(x, PondPrivateTensor) for x in xs):
+            return _concat_private(self, xs, axis=axis)
 
-        elif all([isinstance(x, PondMaskedTensor) for x in xc]):
-            xc_concat = _concat_masked(self, xc, axis=axis)
-        else:
-            raise TypeError("Don't know how to do a concat {}".format(type(xc)))
+        if all(isinstance(x, PondMaskedTensor) for x in xs):
+            return _concat_masked(self, xs, axis=axis)
 
-        return xc_concat
+        raise TypeError("Don't know how to do a concat {}".format(type(xs)))
 
     @memoize
     def sigmoid(self, x: 'PondTensor'):
@@ -846,9 +793,6 @@ class PondTensor(abc.ABC):
 
     This class should never be instantiated on its own.
     """
-
-    prot: Pond
-    is_scaled: bool
 
     def __init__(self, prot: Pond, is_scaled: bool) -> None:
         self.prot = prot
@@ -1267,10 +1211,10 @@ def _cache_private(prot, x):
     with tf.name_scope('cache'):
 
         with tf.device(prot.server_0.device_name):
-            [x0_cached], updator0 = _cache_wrap_helper([x0])
+            [x0_cached], updator0 = _cache_wrap_helper(prot, [x0])
 
         with tf.device(prot.server_1.device_name):
-            [x1_cached], updator1 = _cache_wrap_helper([x1])
+            [x1_cached], updator1 = _cache_wrap_helper(prot, [x1])
 
         updator = tf.group(updator0, updator1)
 
@@ -1293,13 +1237,13 @@ def _cache_masked(prot, x):
     with tf.name_scope('cache'):
 
         with tf.device(prot.crypto_producer.device_name):
-            [a_cached], updator_cp = _cache_wrap_helper([a])
+            [a_cached], updator_cp = _cache_wrap_helper(prot, [a])
 
         with tf.device(prot.server_0.device_name):
-            [a0_cached, alpha_on_0_cached], updator0 = _cache_wrap_helper([a0, alpha_on_0])
+            [a0_cached, alpha_on_0_cached], updator0 = _cache_wrap_helper(prot, [a0, alpha_on_0])
 
         with tf.device(prot.server_1.device_name):
-            [a1_cached, alpha_on_1_cached], updator1 = _cache_wrap_helper([a1, alpha_on_1])
+            [a1_cached, alpha_on_1_cached], updator1 = _cache_wrap_helper(prot, [a1, alpha_on_1])
 
         updator = tf.group(updator_cp, updator0, updator1)
         unmasked_cached = prot.cache(unmasked)
@@ -1912,14 +1856,10 @@ def _dot_public_public(prot, x: PondPublicTensor, y: PondPublicTensor) -> PondPu
     with tf.name_scope('dot'):
 
         with tf.device(prot.server_0.device_name):
-            x = x_on_0
-            y = y_on_0
-            z_on_0 = x.dot(y)
+            z_on_0 = x_on_0.dot(y_on_0)
 
         with tf.device(prot.server_1.device_name):
-            x = x_on_1
-            y = y_on_1
-            z_on_1 = x.dot(y)
+            z_on_1 = x_on_1.dot(y_on_1)
 
     z = PondPublicTensor(prot, z_on_0, z_on_1, x.is_scaled or y.is_scaled)
     z = prot.truncate(z) if x.is_scaled and y.is_scaled else z
@@ -1936,12 +1876,10 @@ def _dot_public_private(prot, x, y):
     with tf.name_scope('dot'):
 
         with tf.device(prot.server_0.device_name):
-            x = x_on_0
-            z0 = x.dot(y0)
+            z0 = x_on_0.dot(y0)
 
         with tf.device(prot.server_1.device_name):
-            x = x_on_1
-            z1 = x.dot(y1)
+            z1 = x_on_1.dot(y1)
 
     z = PondPrivateTensor(prot, z0, z1, x.is_scaled or y.is_scaled)
     z = prot.truncate(z) if x.is_scaled and y.is_scaled else z
@@ -1964,12 +1902,10 @@ def _dot_private_public(prot, x, y):
     with tf.name_scope('dot'):
 
         with tf.device(prot.server_0.device_name):
-            y = y_on_0
-            z0 = x0.dot(y)
+            z0 = x0.dot(y_on_0)
 
         with tf.device(prot.server_0.device_name):
-            y = y_on_1
-            z1 = x1.dot(y)
+            z1 = x1.dot(y_on_1)
 
     z = PondPrivateTensor(prot, z0, z1, x.is_scaled or y.is_scaled)
     z = prot.truncate(z) if x.is_scaled and y.is_scaled else z
@@ -2174,8 +2110,8 @@ def _avgpool2d_im2col_reduce(x: AbstractTensor,
     pool_height, pool_width = pool_size
 
     if padding == "SAME":
-        out_height: int = math.ceil(int(height) / strides[0])
-        out_width: int = math.ceil(int(width) / strides[1])
+        out_height = math.ceil(int(height) / strides[0])
+        out_width = math.ceil(int(width) / strides[1])
     else:
         out_height = math.ceil((int(height) - pool_size[0] + 1) / strides[0])
         out_width = math.ceil((int(width) - pool_size[1] + 1) / strides[1])
@@ -2359,7 +2295,7 @@ def _strided_slice_masked(prot, x: PondMaskedTensor, args: Any, kwargs: Any):
 
 
 def _stack_public(prot: Pond, xs: List[PondPublicTensor], axis: int=0) -> PondPublicTensor:
-    assert all([x.is_scaled for x in xs])
+    assert all(x.is_scaled for x in xs) or all(not x.is_scaled for x in xs)
 
     xs_on_0, xs_on_1 = zip(*(x.unwrapped for x in xs))
 
@@ -2375,7 +2311,7 @@ def _stack_public(prot: Pond, xs: List[PondPublicTensor], axis: int=0) -> PondPu
 
 
 def _stack_private(prot: Pond, xs: List[PondPrivateTensor], axis: int=0) -> PondPrivateTensor:
-    assert all([x.is_scaled for x in xs])
+    assert all(x.is_scaled for x in xs) or all(not x.is_scaled for x in xs)
 
     xs0, xs1 = zip(*(x.unwrapped for x in xs))
 
@@ -2391,7 +2327,7 @@ def _stack_private(prot: Pond, xs: List[PondPrivateTensor], axis: int=0) -> Pond
 
 
 def _stack_masked(prot: Pond, xs: List[PondMaskedTensor], axis: int=0) -> PondMaskedTensor:
-    assert all([x.is_scaled for x in xs])
+    assert all(x.is_scaled for x in xs) or all(not x.is_scaled for x in xs)
 
     a, a0, a1, alpha_on_0, alpha_on_1 = zip(*(x.unwrapped for x in xs))
 
@@ -2422,30 +2358,47 @@ def _stack_masked(prot: Pond, xs: List[PondMaskedTensor], axis: int=0) -> PondMa
     )
 
 
-def _concat_shared(prot: Pond, xc: Union[List[PondPublicTensor], List[PondPrivateTensor]],
-                   axis: int) -> Union[PondPublicTensor, PondPrivateTensor]:
-    assert all([x.is_scaled for x in xc])
+#
+# concat helpers
+#
 
-    xc_on_0, xc_on_1 = zip(*(x.unwrapped for x in xc))
+
+def _concat_public(prot: Pond, xs: List[PondPublicTensor], axis: int) -> PondPublicTensor:
+    assert all(x.is_scaled for x in xs) or all(not x.is_scaled for x in xs)
+
+    xs_on_0, xs_on_1 = zip(*(x.unwrapped for x in xs))
 
     with tf.name_scope('concat'):
 
         with tf.device(prot.server_0.device_name):
-            x_on_0_concat = prot.tensor_factory.Tensor.concat(xc_on_0, axis=axis)
+            x_on_0_concat = prot.tensor_factory.Tensor.concat(xs_on_0, axis=axis)
 
         with tf.device(prot.server_1.device_name):
-            x_on_1_concat = prot.tensor_factory.Tensor.concat(xc_on_1, axis=axis)
+            x_on_1_concat = prot.tensor_factory.Tensor.concat(xs_on_1, axis=axis)
 
-    if isinstance(xc[0], PondPrivateTensor):
-        return PondPrivateTensor(prot, x_on_0_concat, x_on_1_concat, xc[0].is_scaled)
-    else:
-        return PondPublicTensor(prot, x_on_0_concat, x_on_1_concat, xc[0].is_scaled)
+    return PondPublicTensor(prot, x_on_0_concat, x_on_1_concat, xs[0].is_scaled)
 
 
-def _concat_masked(prot: Pond, xc: List[PondMaskedTensor], axis: int) -> PondMaskedTensor:
-    assert all([x.is_scaled for x in xc])
+def _concat_private(prot: Pond, xs: List[PondPrivateTensor], axis: int) -> PondPrivateTensor:
+    assert all(x.is_scaled for x in xs) or all(not x.is_scaled for x in xs)
 
-    a, a0, a1, alpha_on_0, alpha_on_1 = zip(*(x.unwrapped for x in xc))
+    xs0, xs1 = zip(*(x.unwrapped for x in xs))
+
+    with tf.name_scope('concat'):
+
+        with tf.device(prot.server_0.device_name):
+            x0_concat = prot.tensor_factory.Tensor.concat(xs0, axis=axis)
+
+        with tf.device(prot.server_1.device_name):
+            x1_concat = prot.tensor_factory.Tensor.concat(xs1, axis=axis)
+
+    return PondPrivateTensor(prot, x0_concat, x1_concat, xs[0].is_scaled)
+
+
+def _concat_masked(prot: Pond, xs: List[PondMaskedTensor], axis: int) -> PondMaskedTensor:
+    assert all(x.is_scaled for x in xs) or all(not x.is_scaled for x in xs)
+
+    a, a0, a1, alpha_on_0, alpha_on_1 = zip(*(x.unwrapped for x in xs))
 
     with tf.name_scope('concat'):
 
@@ -2460,7 +2413,7 @@ def _concat_masked(prot: Pond, xc: List[PondMaskedTensor], axis: int) -> PondMas
             a1_concat = prot.tensor_factory.Tensor.concat(a1, axis=axis)
             alpha_on_1_concat = prot.tensor_factory.Tensor.concat(alpha_on_1, axis=axis)
 
-        x_unmasked_concat = prot.concat([x.unmasked for x in xc], axis=axis)
+        x_unmasked_concat = prot.concat([x.unmasked for x in xs], axis=axis)
 
     return PondMaskedTensor(
         prot,
@@ -2470,7 +2423,7 @@ def _concat_masked(prot: Pond, xc: List[PondMaskedTensor], axis: int) -> PondMas
         a1_concat,
         alpha_on_0_concat,
         alpha_on_1_concat,
-        xc[0].is_scaled
+        xs[0].is_scaled
     )
 
 
@@ -2598,8 +2551,7 @@ def _expand_dims_public(prot: Pond, x: PondPublicTensor, axis: Optional[int]=Non
     return PondPublicTensor(prot, x_on_0_e, x_on_1_e, x.is_scaled)
 
 
-def _expand_dims_private(prot: Pond, x: PondPrivateTensor,
-                         axis: Optional[int]=None) -> PondPrivateTensor:
+def _expand_dims_private(prot: Pond, x: PondPrivateTensor, axis: Optional[int]=None) -> PondPrivateTensor:
     assert isinstance(x, PondPrivateTensor)
 
     x0, x1 = x.unwrapped

--- a/tensorflow_encrypted/protocol/protocol.py
+++ b/tensorflow_encrypted/protocol/protocol.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Optional, Type, List, Dict, Any
+from typing import Optional, Type, Any
 from types import TracebackType
 
 import tensorflow as tf
@@ -8,8 +8,8 @@ from ..tensor.tensor import AbstractTensor
 
 
 _current_prot = None
-global_cache_updators: List = []
-nodes: Dict = {}
+global_cache_updators = list()
+nodes = dict()
 
 
 class Protocol(object):

--- a/tensorflow_encrypted/protocol/securenn.py
+++ b/tensorflow_encrypted/protocol/securenn.py
@@ -1,6 +1,6 @@
 from .protocol import memoize
 from ..protocol.pond import (
-    Pond, PondTensor, PondPrivateTensor
+    Pond, PondTensor
 )
 from ..player import Player
 
@@ -85,10 +85,7 @@ class SecureNN(Pond):
 
     @memoize
     def select_share(self, x: PondTensor, y: PondTensor, bit: PondTensor) -> PondTensor:
-        w = y - x
-        c = bit * w
-
-        return x + c + PondPrivateTensor.zero(x.prot, x.shape)
+        return x + bit * (y - x)
 
     def private_compare(self, x, r, beta):
         raise NotImplementedError

--- a/tensorflow_encrypted/tensor/crt.py
+++ b/tensorflow_encrypted/tensor/crt.py
@@ -136,8 +136,8 @@ def crt_matmul_split(x: TFEData, y: TFEData, threshold: int) -> List[Tuple[TFEDa
             left = i * threshold
             right = (i + 1) * threshold
 
-            inner_x: List[Union[tf.Tensor, np.ndarray]] = []
-            inner_y: List[Union[tf.Tensor, np.ndarray]] = []
+            inner_x = []
+            inner_y = []
 
             for xi, yi in zip(x, y):
                 inner_x.append(xi[:, left:right])

--- a/tensorflow_encrypted/tensor/crt.py
+++ b/tensorflow_encrypted/tensor/crt.py
@@ -136,8 +136,8 @@ def crt_matmul_split(x: TFEData, y: TFEData, threshold: int) -> List[Tuple[TFEDa
             left = i * threshold
             right = (i + 1) * threshold
 
-            inner_x = []
-            inner_y = []
+            inner_x = []  # type: List[Union[tf.Tensor, np.ndarray]]
+            inner_y = []  # type: List[Union[tf.Tensor, np.ndarray]]
 
             for xi, yi in zip(x, y):
                 inner_x.append(xi[:, left:right])

--- a/tensorflow_encrypted/tensor/helpers.py
+++ b/tensorflow_encrypted/tensor/helpers.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from math import log
-from typing import Tuple, List, Callable
+from typing import Tuple
 
 
 def egcd(a: int, b: int) -> Tuple[int, int, int]:
@@ -21,5 +21,5 @@ def inverse(a: int, m: int) -> int:
     return b % m
 
 
-log2: Callable[[int], float] = lambda x: log(x) / log(2)
-prod: Callable[[List[int]], int] = lambda xs: reduce(lambda x, y: x * y, xs)
+log2 = lambda x: log(x) / log(2)
+prod = lambda xs: reduce(lambda x, y: x * y, xs)

--- a/tensorflow_encrypted/tensor/int100.py
+++ b/tensorflow_encrypted/tensor/int100.py
@@ -56,7 +56,6 @@ class Int100Tensor(AbstractTensor):
 
     modulus = M
     int_type = INT_TYPE
-    backing: Union[List[np.ndarray], List[tf.Tensor]]
 
     def __init__(
         self,
@@ -131,7 +130,7 @@ class Int100Tensor(AbstractTensor):
         return _sample_bounded(shape, bitlength)
 
     def __getitem__(self, slice):
-        return self.from_decomposed([x[slice] for x in self.decomposed_value])
+        return self.from_decomposed([x[slice] for x in self.backing])
 
     def __repr__(self) -> str:
         return 'Int100Tensor({})'.format(self.shape)

--- a/tensorflow_encrypted/tensor/prime.py
+++ b/tensorflow_encrypted/tensor/prime.py
@@ -229,7 +229,7 @@ class PrimePlaceholder(PrimeTensor):
 class PrimeVariable(PrimeTensor):
     def __init__(self, initial_value: Union[tf.Tensor, np.ndarray], modulus: int) -> None:
         variable = tf.Variable(initial_value, dtype=INT_TYPE, trainable=False)
-        value: Union[tf.Tensor, np.ndarray] = variable.read_value()
+        value = variable.read_value()
 
         super(PrimeVariable, self).__init__(value, modulus)
         self.variable = variable


### PR DESCRIPTION
closes #167 

- removed some type hints, yet all of them can easily be inferred directly so don't think this makes a big difference

- fixed a few indentation bugs in Pond

- memoized a few methods in Pond

- lowered the required TF version to 1.9 to get it running on RPIs

note: I tried to get `strip-hints` to work, but it appears to be a runtime thing only that didn't make me convinced