### PR TITLE
name scope binarize function

### DIFF
--- a/tensorflow_encrypted/tensor/native_shared.py
+++ b/tensorflow_encrypted/tensor/native_shared.py
@@ -5,14 +5,15 @@ from .prime import PrimeTensor
 
 
 def binarize(tensor: AbstractTensor, prime: int=37) -> PrimeTensor:
-    BITS = tensor.int_type.size * 8
-    assert prime > BITS, prime
+    with tf.name_scope('binarize'):
+        BITS = tensor.int_type.size * 8
+        assert prime > BITS, prime
 
-    final_shape = [1] * len(tensor.shape) + [BITS]
-    bitwidths = tf.range(BITS, dtype=tf.int32)
-    bitwidths = tf.reshape(bitwidths, final_shape)
+        final_shape = [1] * len(tensor.shape) + [BITS]
+        bitwidths = tf.range(BITS, dtype=tf.int32)
+        bitwidths = tf.reshape(bitwidths, final_shape)
 
-    val = tf.expand_dims(tensor.value, -1)
-    val = tf.bitwise.bitwise_and(tf.bitwise.right_shift(val, bitwidths), 1)
+        val = tf.expand_dims(tensor.value, -1)
+        val = tf.bitwise.bitwise_and(tf.bitwise.right_shift(val, bitwidths), 1)
 
-    return PrimeTensor.from_native(val, prime)
+        return PrimeTensor.from_native(val, prime)


### PR DESCRIPTION
binarize crowds the graph in tensorboard quite a bit, name scoping
it makes it a lot easier to read

### With a simple graph for clarity
#### Before

![image](https://user-images.githubusercontent.com/1411145/46022951-f6638480-c0b9-11e8-84e9-f4e68d9b62ae.png)


#### After

![image](https://user-images.githubusercontent.com/1411145/46022875-d2a03e80-c0b9-11e8-8f3f-2c72bf1a4e43.png)

![image](https://user-images.githubusercontent.com/1411145/46022882-d764f280-c0b9-11e8-855f-a77435e4a330.png)
