### PR TITLE
Make TFE runnable in python 3.5 again

### DIFF
--- a/tensorflow_encrypted/tensor/tensor.py
+++ b/tensorflow_encrypted/tensor/tensor.py
@@ -10,8 +10,6 @@ TFTypes = Union[
 
 
 class AbstractTensor(ABC):
-    int_type: TFTypes
-    value: Union[tf.Tensor, np.ndarray]
 
     @abstractmethod
     def __init__(self, value: Union[np.ndarray, tf.Tensor]) -> None:

--- a/tensorflow_encrypted/tensor/tensor.py
+++ b/tensorflow_encrypted/tensor/tensor.py
@@ -1,12 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import List, Union, Type, Tuple
+from typing import List, Union, Tuple
+
 import numpy as np
 import tensorflow as tf
-
-TFTypes = Union[
-    Type['tf.int32'],
-    Type['tf.int64'],
-]
 
 
 class AbstractTensor(ABC):


### PR DESCRIPTION
I didn't find the two removed fields to actually make a lot of sense in the `AbstractTensor` class since `int_type` is specific implementation detail and `value` don't apply to int100 tensors -- so I removed them instead of switching to older type hints.