### PR TITLE
Require Python 3.5 for development and Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ variables:
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.4
+      - image: circleci/python:3.5
     working_directory: ~/repo
     steps:
       - *docker-caching
@@ -49,7 +49,7 @@ jobs:
             make test
   deploy:
     docker:
-      - image: circleci/python:3.6.4
+      - image: circleci/python:3.5
     working_directory: ~/repo
     steps:
       - *docker-caching

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifeq (,$(BYPASS_TENSORFLOW_CHECK))
 endif
 endif
 
-bootstrap: pythoncheck pipcheck tensorflowcheck
+bootstrap: pythoncheck pipcheck
 	pip install -r requirements.txt
 	pip install -e .
 
@@ -58,7 +58,7 @@ bootstrap: pythoncheck pipcheck tensorflowcheck
 #
 # Rules for running our tests and for running various different linters
 # ###############################################
-test: lint pythoncheck
+test: lint pythoncheck tensorflowcheck
 	python examples/convert.py
 	python examples/inputs.py
 	python examples/int32.py
@@ -69,10 +69,10 @@ test: lint pythoncheck
 	python examples/federated-average/run.py
 	python -m unittest discover
 
-lint: pythoncheck
+lint: pythoncheck tensorflowcheck
 	flake8
 
-typecheck: pythoncheck
+typecheck: pythoncheck tensorflowcheck
 	MYPYPATH=$(CURRENT_DIR):$(CURRENT_DIR)/stubs mypy tensorflow_encrypted
 
 
@@ -183,7 +183,7 @@ docker-push: docker-push-$(PUSHTYPE)
 # variables to be set to be executed properly.
 # ##############################################
 
-pypicheck: pipcheck pythoncheck
+pypicheck: pipcheck pythoncheck tensorflowcheck
 ifeq (,$(PYPI_USERNAME))
 ifeq (,$(PYPI_PASSWORD))
 	$(error "Missing PYPI_USERNAME and PYPI_PASSWORD environment variables")

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: test
 # Rules for bootstrapping the Makefile such as checking for docker, python versions, etc.
 # ###############################################
 DOCKER_REQUIRED_VERSION=18.
-PYTHON_REQUIRED_VERSION=3.6.
+PYTHON_REQUIRED_VERSION=3.5.
 TENSORFLOW_REQUIRED_VERSION=1.10
 SHELL := /bin/bash
 

--- a/examples/bench_conv2d_sigmoid.py
+++ b/examples/bench_conv2d_sigmoid.py
@@ -1,5 +1,4 @@
 import sys
-from typing import List
 
 import tensorflow as tf
 import tensorflow_encrypted as tfe
@@ -29,7 +28,7 @@ if len(sys.argv) > 1:
     # assume we're running as a server
     #
 
-    player_name: str = str(sys.argv[1])
+    player_name = str(sys.argv[1])
 
     server = config.server(player_name)
     server.start()
@@ -41,28 +40,28 @@ else:
     #
 
     input_shape = [1, 3, 192, 192]
-    conv11_fshape: List = [3, 3, 3, 64]
-    conv12_fshape: List = [3, 3, 64, 64]
-    pool1_shape: List = [1, 1, 64, 64]
+    conv11_fshape = [3, 3, 3, 64]
+    conv12_fshape = [3, 3, 64, 64]
+    pool1_shape = [1, 1, 64, 64]
 
-    conv21_fshape: List = [3, 3, 64, 128]
-    conv22_fshape: List = [3, 3, 128, 128]
-    pool2_shape: List = [1, 1, 128, 128]
+    conv21_fshape = [3, 3, 64, 128]
+    conv22_fshape = [3, 3, 128, 128]
+    pool2_shape = [1, 1, 128, 128]
 
-    conv31_fshape: List = [3, 3, 128, 256]
-    conv32_fshape: List = [3, 3, 256, 256]
-    conv33_fshape: List = [3, 3, 256, 256]
-    pool3_shape: List = [1, 1, 256, 256]
+    conv31_fshape = [3, 3, 128, 256]
+    conv32_fshape = [3, 3, 256, 256]
+    conv33_fshape = [3, 3, 256, 256]
+    pool3_shape = [1, 1, 256, 256]
 
-    conv41_fshape: List = [3, 3, 256, 512]
-    conv42_fshape: List = [3, 3, 512, 512]
-    conv43_fshape: List = [3, 3, 512, 512]
-    pool4_shape: List = [1, 1, 512, 512]
+    conv41_fshape = [3, 3, 256, 512]
+    conv42_fshape = [3, 3, 512, 512]
+    conv43_fshape = [3, 3, 512, 512]
+    pool4_shape = [1, 1, 512, 512]
 
-    conv51_fshape: List = [3, 3, 512, 512]
-    conv52_fshape: List = [3, 3, 512, 512]
-    conv53_fshape: List = [3, 3, 512, 512]
-    pool5_shape: List = [1, 1, 512, 512]
+    conv51_fshape = [3, 3, 512, 512]
+    conv52_fshape = [3, 3, 512, 512]
+    conv53_fshape = [3, 3, 512, 512]
+    pool5_shape = [1, 1, 512, 512]
 
     def provide_input_conv11weights() -> tf.Tensor:
         w = tf.random_normal(shape=conv11_fshape, dtype=tf.float32)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ termcolor==1.1.0
 typed-ast==1.1.0
 urllib3==1.23
 Werkzeug==0.14.1
+tensorflow==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setuptools.setup(
         "numpy>=1.14.0"
     ],
     extra_requires={
-        "tf": ["tensorflow>=1.9.0"],
-        "tf_gpu": ["tensorflow-gpu>=1.9.0"]
+        "tf": ["tensorflow>=1.10.0"],
+        "tf_gpu": ["tensorflow-gpu>=1.10.0"]
     },
     license="Apache License 2.0",
     url="https://github.com/mortendahl/tf-encrypted",

--- a/tensorflow_encrypted/convert/convert.py
+++ b/tensorflow_encrypted/convert/convert.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, List, Any, Union, Optional
+from typing import Dict, List, Any, Union, Optional
 
 from ..player import Player
 from ..protocol import Pond, get_protocol
@@ -35,8 +35,6 @@ class Converter():
             input_player = get_config().get_player('input-provider')
         assert isinstance(input_player, Player)
 
-        name_to_input_name, name_to_node = extract_graph_summary(graph_def)
-
         if inputter_fn is None:
             inputs = []
         elif type(inputter_fn) is list:
@@ -45,8 +43,9 @@ class Converter():
             inputs = [inputter_fn]
         inputs_iterable = enumerate(inputs)
 
-        for output, inputs in name_to_input_name.items():
-            node = name_to_node[output]
+        for node in graph_def.node:
+            output = node_name(node.name)
+            inputs = [node_name(x) for x in node.input]
 
             if node.op == "Placeholder":
                 try:
@@ -69,21 +68,6 @@ def node_name(n: str) -> str:
         return n[1:]
     else:
         return n.split(":")[0]
-
-
-def extract_graph_summary(graph_def: Any) -> Tuple[Dict[str, List[str]],
-                                                   Dict[str, Any]]:
-    """Extracts useful information from the graph and returns them."""
-    name_to_input_name = {}  # Keyed by the dest node name.
-    name_to_node = {}  # Keyed by node name.
-
-    for node in graph_def.node:
-        name = node.name
-        n = node_name(name)
-        name_to_node[n] = node
-        name_to_input_name[n] = [node_name(x) for x in node.input]
-
-    return name_to_input_name, name_to_node
 
 
 class InvalidArgumentError(Exception):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -15,7 +15,7 @@ from tensorflow.python.framework import graph_util
 from tensorflow.python.framework import graph_io
 
 
-global_filename: str = ''
+global_filename = ''
 
 
 class TestConvert(unittest.TestCase):


### PR DESCRIPTION
In our setup.py we advertise that we supported Python 3.5, however, we
don't actually test whether we support 3.5 as a part of our continuous
integration suite.

Therefore, I've switched Circle CI over to 3.5 and updated our Makefile
to check that the callee is using 3.5 to test and publish our artifacts.

Closes #211
