### PR TITLE
Batch size + rsqrt

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -24,6 +24,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument(
     "--model_name", type=str, default='', help="Model name")
 parser.add_argument(
+    "--batch_size", type=str, default='', help="Batch size")
+parser.add_argument(
     "--model_url", type=str, default='', help="Model's public URL")
 parser.add_argument(
     '--input_file', type=str, default="", help='load the data from a numpy file format (.npy)')
@@ -66,7 +68,7 @@ with gfile.FastGFile(model_file, 'rb') as f:
         input_spec.append({
             'name': node.name,
             'dtype': node.attr['dtype'].type,
-            'shape': [int(d.size) if d.size > 0 else 1 for d in node.attr['shape'].shape.dim]
+            'shape': [config.batch_size] + [int(d.size) if d.size > 0 else 1 for d in node.attr['shape'].shape.dim[1:]]
         })
 
 inputs = []
@@ -108,7 +110,7 @@ with tfe.Session() as sess:
 
     print("running")
     feed_dict = {
-        pl: input_data[i] for i, pl in enumerate(pls)
+        pl: input_data for i, pl in enumerate(pls)
     }
     output = sess.run(
         y.reveal(),

--- a/bin/run
+++ b/bin/run
@@ -24,7 +24,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument(
     "--model_name", type=str, default='', help="Model name")
 parser.add_argument(
-    "--batch_size", type=str, default='', help="Batch size")
+    "--batch_size", type=int, default=1, help="Batch size")
 parser.add_argument(
     "--model_url", type=str, default='', help="Model's public URL")
 parser.add_argument(
@@ -68,7 +68,7 @@ with gfile.FastGFile(model_file, 'rb') as f:
         input_spec.append({
             'name': node.name,
             'dtype': node.attr['dtype'].type,
-            'shape': [config.batch_size] + [int(d.size) if d.size > 0 else 1 for d in node.attr['shape'].shape.dim[1:]]
+            'shape': [config.batch_size] + [int(d.size) for d in node.attr['shape'].shape.dim[1:]]
         })
 
 inputs = []
@@ -96,7 +96,11 @@ for i in range(len(input_spec)):
     )
 
 if config.input_file != '':
-    input_data = np.load(config.input_file)
+    # TODO: Currently this allows for only one input
+    # If we want to load models with multiple diffrent inputs
+    # We will need to save our inputs as a list of np.array
+    input_data = [np.load(config.input_file)]
+    assert len(input_data) == len(input_spec), 'the input_data length ({}) should be equal the number of inputs required by the loaded model ({})'.format(len(input_data), len(input_spec))
 else:
     input_data = []
     for spec in input_spec:
@@ -110,7 +114,7 @@ with tfe.Session() as sess:
 
     print("running")
     feed_dict = {
-        pl: input_data for i, pl in enumerate(pls)
+        pl: input_data[i] for i, pl in enumerate(pls)
     }
     output = sess.run(
         y.reveal(),

--- a/tensorflow_encrypted/convert/register.py
+++ b/tensorflow_encrypted/convert/register.py
@@ -259,7 +259,11 @@ def rsqrt(converter: Converter, node: Any, inputs: List[str]) -> Any:
 
         x = tf.rsqrt(decoded)
 
-    inputter_fn = lambda: tf.constant(x)
+    if isinstance(x,tf.Tensor):
+        inputter_fn = lambda: x
+    else:
+        inputter_fn = lambda: tf.constant(x)
+
     x = converter.protocol.define_public_input(converter.model_provider, inputter_fn)
 
     return x

--- a/tensorflow_encrypted/convert/register.py
+++ b/tensorflow_encrypted/convert/register.py
@@ -259,7 +259,7 @@ def rsqrt(converter: Converter, node: Any, inputs: List[str]) -> Any:
 
         x = tf.rsqrt(decoded)
 
-    if isinstance(x,tf.Tensor):
+    if isinstance(x, tf.Tensor):
         inputter_fn = lambda: x
     else:
         inputter_fn = lambda: tf.constant(x)

--- a/tensorflow_encrypted/convert/register.py
+++ b/tensorflow_encrypted/convert/register.py
@@ -251,18 +251,13 @@ def rsqrt(converter: Converter, node: Any, inputs: List[str]) -> Any:
         else:
             raise TypeError("Unsupported dtype for rsqrt")
 
-        x = 1 / np.sqrt(np.array(nums).reshape(shape))
+        inputter_fn = lambda: tf.constant(1 / np.sqrt(np.array(nums).reshape(shape)))
     else:
         # XXX this is a little weird but the input into rsqrt is public and
         # being used only for batchnorm at the moment
         decoded = converter.protocol._decode(input.value_on_0, True)
 
-        x = tf.rsqrt(decoded)
-
-    if isinstance(x, tf.Tensor):
-        inputter_fn = lambda: x
-    else:
-        inputter_fn = lambda: tf.constant(x)
+        inputter_fn = lambda: tf.rsqrt(decoded)
 
     x = converter.protocol.define_public_input(converter.model_provider, inputter_fn)
 


### PR DESCRIPTION
Hello @morgangiraud,

I have tried to run a model with batchnorm on an input of shape (1,784). I am getting some small errors:

`Traceback (most recent call last):
  File "../bin/run", line 118, in <module>
    tag='prediction'
  File "/Users/yanndupis/Documents/dropoutlabs/tf-encrypted/tensorflow_encrypted/session.py", line 75, in run
    feed_dict=feed_dict
  File "/anaconda3/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 877, in run
    run_metadata_ptr)
  File "/anaconda3/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1076, in _run
    str(subfeed_t.get_shape())))
ValueError: Cannot feed value of shape (784,) for Tensor 'private-input/api/0:0', which has shape '(1, 784)'`

I have modified the code so we have to specify the batch size. But ideally I think we would like to have the batch size inferred based on the batch size. 

I was also getting the following error for rsqrt (generated by batchnorm):
`Traceback (most recent call last):
  File "./bin/run", line 84, in <module>
    y = c.convert(graph_def, tfe.convert.register(), 'input-provider', inputs)
  File "/Users/yanndupis/Documents/dropoutlabs/tf-encrypted/tensorflow_encrypted/convert/convert.py", line 62, in convert
    self.outputs[output] = register[node.op](self, node, inputs)
  File "/Users/yanndupis/Documents/dropoutlabs/tf-encrypted/tensorflow_encrypted/convert/register.py", line 263, in rsqrt
    x = converter.protocol.define_public_input(converter.model_provider, inputter_fn)
  File "/Users/yanndupis/Documents/dropoutlabs/tf-encrypted/tensorflow_encrypted/protocol/pond.py", line 240, in define_public_input
    inputs = inputter_fn()
  File "/Users/yanndupis/Documents/dropoutlabs/tf-encrypted/tensorflow_encrypted/convert/register.py", line 262, in <lambda>
    inputter_fn = lambda: tf.constant(x)
  File "/anaconda3/lib/python3.6/site-packages/tensorflow/python/framework/constant_op.py", line 196, in constant
    value, dtype=dtype, shape=shape, verify_shape=verify_shape))
  File "/anaconda3/lib/python3.6/site-packages/tensorflow/python/framework/tensor_util.py", line 436, in make_tensor_proto
    _AssertCompatible(values, dtype)
  File "/anaconda3/lib/python3.6/site-packages/tensorflow/python/framework/tensor_util.py", line 344, in _AssertCompatible
    raise TypeError("List of Tensors when single Tensor expected")
TypeError: List of Tensors when single Tensor expected`

It's because tf.rsqrt output a tensor and not an np.array.

Feel free to add new commits to this pr. I am going to work on a separate PR to be able to select the protocol (Pond or Securenn) when we benchmark the models. Ideally, It would be great to have everything working tomorrow :) 