### PR TITLE
Skip tensorflowcheck on push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ docker-push: docker-push-$(PUSHTYPE)
 # variables to be set to be executed properly.
 # ##############################################
 
-pypicheck: pipcheck pythoncheck tensorflowcheck
+pypicheck: pipcheck pythoncheck
 ifeq (,$(PYPI_USERNAME))
 ifeq (,$(PYPI_PASSWORD))
 	$(error "Missing PYPI_USERNAME and PYPI_PASSWORD environment variables")


### PR DESCRIPTION
In our deploy environmnet we don't have tensorflow installed nor do we
need it installed as all we're doing is packaging up the raw source code
for distribution.

Therefore, to fix the build, I've removed the `tensorflowcheck` from
`make push`!