### PR TITLE
basic int64 support 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: test
 # ###############################################
 DOCKER_REQUIRED_VERSION=18.
 PYTHON_REQUIRED_VERSION=3.5.
-TENSORFLOW_REQUIRED_VERSION=1.11
+TENSORFLOW_REQUIRED_VERSION=1.10
 SHELL := /bin/bash
 
 CURRENT_DIR=$(shell pwd)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: test
 # ###############################################
 DOCKER_REQUIRED_VERSION=18.
 PYTHON_REQUIRED_VERSION=3.5.
-TENSORFLOW_REQUIRED_VERSION=1.10
+TENSORFLOW_REQUIRED_VERSION=1.11
 SHELL := /bin/bash
 
 CURRENT_DIR=$(shell pwd)

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ bootstrap: pythoncheck pipcheck
 #
 # Rules for running our tests and for running various different linters
 # ###############################################
-test: lint pythoncheck tensorflowcheck
+test: lint pythoncheck
 	python examples/convert.py
 	python examples/inputs.py
 	python examples/int32.py
@@ -69,10 +69,10 @@ test: lint pythoncheck tensorflowcheck
 	python examples/federated-average/run.py
 	python -m unittest discover
 
-lint: pythoncheck tensorflowcheck
+lint: pythoncheck
 	flake8
 
-typecheck: pythoncheck tensorflowcheck
+typecheck: pythoncheck
 	MYPYPATH=$(CURRENT_DIR):$(CURRENT_DIR)/stubs mypy tensorflow_encrypted
 
 

--- a/examples/matmul.py
+++ b/examples/matmul.py
@@ -42,4 +42,4 @@ with tfe.Session() as sess:
     actual = sess.run(y.reveal(), tag='reveal')
 
     expected = b
-    np.testing.assert_allclose(actual, expected, atol=.1)
+    np.testing.assert_allclose(actual, expected)

--- a/examples/matmul.py
+++ b/examples/matmul.py
@@ -42,4 +42,4 @@ with tfe.Session() as sess:
     actual = sess.run(y.reveal(), tag='reveal')
 
     expected = b
-    np.testing.assert_array_equal(actual, expected)
+    np.testing.assert_allclose(actual, expected, atol=.1)

--- a/tensorflow_encrypted/config.py
+++ b/tensorflow_encrypted/config.py
@@ -12,9 +12,9 @@ from .player import Player
 def tensorflow_supports_int64() -> bool:
     # hacky way to test if int64 is supported by this build of TensorFlow
     with tf.Graph().as_default():
-        x = tf.constant([1], shape=(1,1), dtype=tf.int64)
+        x = tf.constant([1], shape=(1, 1), dtype=tf.int64)
         try:
-            _y = tf.matmul(x, x)
+            tf.matmul(x, x)
         except TypeError:
             return False
         else:

--- a/tensorflow_encrypted/config.py
+++ b/tensorflow_encrypted/config.py
@@ -9,6 +9,18 @@ import tensorflow as tf
 from .player import Player
 
 
+def tensorflow_supports_int64() -> bool:
+    # hacky way to test if int64 is supported by this build of TensorFlow
+    with tf.Graph().as_default():
+        x = tf.constant([1], shape=(1,1), dtype=tf.int64)
+        try:
+            _y = tf.matmul(x, x)
+        except TypeError:
+            return False
+        else:
+            return True
+
+
 def get_docker_cpu_quota() -> Optional[int]:
     cpu_cores = None
 

--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -433,7 +433,6 @@ class Pond(Protocol):
 
         with tf.name_scope('share'):
             share0 = secret.factory.sample_uniform(secret.shape)
-            print(secret.factory.native_type, share0.factory.native_type)
             share1 = secret - share0
 
         return share0, share1

--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -108,9 +108,9 @@ class Pond(Protocol):
         server_0: Optional[Player] = None,
         server_1: Optional[Player] = None,
         crypto_producer: Optional[Player] = None,
-        tensor_factory: AbstractFactory = int100factory,
-        fixedpoint_config: FixedpointConfig = fixedpoint_int100,
-        use_noninteractive_truncation: bool = False,
+        tensor_factory: AbstractFactory = int64factory,
+        fixedpoint_config: FixedpointConfig = fixedpoint_int64,
+        use_noninteractive_truncation: bool = True,
     ) -> None:
 
         self.server_0 = server_0 or get_config().get_player('server0')

--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -108,8 +108,8 @@ class Pond(Protocol):
         server_0: Optional[Player] = None,
         server_1: Optional[Player] = None,
         crypto_producer: Optional[Player] = None,
-        tensor_factory: AbstractFactory = int64factory,
-        fixedpoint_config: FixedpointConfig = fixedpoint_int64,
+        tensor_factory: AbstractFactory = int100factory,
+        fixedpoint_config: FixedpointConfig = fixedpoint_int100,
         use_noninteractive_truncation: bool = True,
     ) -> None:
 

--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -110,7 +110,7 @@ class Pond(Protocol):
         crypto_producer: Optional[Player] = None,
         tensor_factory: AbstractFactory = int100factory,
         fixedpoint_config: FixedpointConfig = fixedpoint_int100,
-        use_noninteractive_truncation: bool = True,
+        use_noninteractive_truncation: bool = False,
     ) -> None:
 
         self.server_0 = server_0 or get_config().get_player('server0')

--- a/tensorflow_encrypted/protocol/pond.py
+++ b/tensorflow_encrypted/protocol/pond.py
@@ -10,8 +10,8 @@ import tensorflow as tf
 from ..tensor.helpers import inverse
 from ..tensor.factory import AbstractFactory, AbstractTensor, AbstractConstant, AbstractVariable, AbstractPlaceholder
 from ..tensor.fixed import FixedpointConfig
-# from ..tensor import int100factory, fixed100_i
-from ..tensor import int64factory, fixed64_i
+# from ..tensor import int100factory, fixed100
+from ..tensor import int64factory, fixed64
 from ..types import Slice, Ellipse
 from ..player import Player
 from ..config import get_config
@@ -37,7 +37,7 @@ class Pond(Protocol):
         server_1: Optional[Player] = None,
         crypto_producer: Optional[Player] = None,
         tensor_factory: AbstractFactory = int64factory,
-        fixedpoint_config: FixedpointConfig = fixed64_i,
+        fixedpoint_config: FixedpointConfig = fixed64,
     ) -> None:
 
         self.server_0 = server_0 or get_config().get_player('server0')

--- a/tensorflow_encrypted/protocol/securenn.py
+++ b/tensorflow_encrypted/protocol/securenn.py
@@ -41,8 +41,14 @@ class SecureNN(Pond):
         )
         self.server_2 = server_2
 
-        self.prime_factory = prime_factory or PrimeFactory(107, native_type=self.tensor_factory.native_type)
-        self.odd_factory = odd_factory or self.tensor_factory
+        if prime_factory is None:
+            prime_factory = PrimeFactory(107, native_type=self.tensor_factory.native_type)
+
+        if odd_factory is None:
+            odd_factory = self.tensor_factory
+
+        self.prime_factory = prime_factory
+        self.odd_factory = odd_factory
         assert self.prime_factory.native_type == self.tensor_factory.native_type
         assert self.odd_factory.native_type == self.tensor_factory.native_type
 

--- a/tensorflow_encrypted/protocol/securenn.py
+++ b/tensorflow_encrypted/protocol/securenn.py
@@ -72,11 +72,13 @@ class SecureNN(Pond):
     @memoize
     def msb(self, x: PondTensor) -> PondTensor:
         # NOTE when the modulus is odd then msb reduces to lsb via x -> 2*x
-        if x.backing_dtype.modulus % 2 != 1:
-            # NOTE: this is currently only for use with an odd-modulus CRTTensor
-            #       NativeTensor will use an even modulus and will require share_convert
-            raise Exception('SecureNN protocol assumes a ring of odd cardinality, ' +
-                            'but it was initialized with an even one.')
+
+        # if x.backing_dtype.modulus % 2 != 1:
+        #     # NOTE: this is currently only for use with an odd-modulus CRTTensor
+        #     #       NativeTensor will use an even modulus and will require share_convert
+        #     raise Exception('SecureNN protocol assumes a ring of odd cardinality, ' +
+        #                     'but it was initialized with an even one.')
+
         return self.lsb(x * 2)
 
     @memoize

--- a/tensorflow_encrypted/protocol/securenn.py
+++ b/tensorflow_encrypted/protocol/securenn.py
@@ -39,8 +39,11 @@ class SecureNN(Pond):
             **kwargs
         )
         self.server_2 = server_2
-        self.prime_factory = prime_factory or PrimeFactory(107)
+
+        self.prime_factory = prime_factory or PrimeFactory(107, native_type=self.tensor_factory.native_type)
         self.odd_factory = odd_factory or self.tensor_factory
+        assert self.prime_factory.native_type == self.tensor_factory.native_type
+        assert self.odd_factory.native_type == self.tensor_factory.native_type
 
     @memoize
     def bitwise_not(self, x: PondTensor) -> PondTensor:
@@ -271,7 +274,7 @@ def _private_compare(prot, x_bits: PondPrivateTensor, r: PondPublicTensor, beta:
                 prot.equal_zero(s, prime_dtype)
             )
             edge_cases = prot.expand_dims(edge_cases, axis=-1)
-            c_edge_case_raw = prime_dtype.tensor(tf.constant([0] + [1] * (bit_length - 1), dtype=tf.int32, shape=(1, bit_length)))
+            c_edge_case_raw = prime_dtype.tensor(tf.constant([0] + [1] * (bit_length - 1), dtype=prime_dtype.native_type, shape=(1, bit_length)))
             c_edge_case = prot._share_and_wrap(c_edge_case_raw, False)
 
             c = prot.select(

--- a/tensorflow_encrypted/tensor/__init__.py
+++ b/tensorflow_encrypted/tensor/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from .int100 import (
+    int100factory,
     Int100Constant,
     Int100Placeholder,
     Int100Variable,
@@ -8,6 +9,7 @@ from .int100 import (
 )
 
 from .prime import (
+    PrimeFactory,
     PrimeTensor,
     PrimePlaceholder,
     PrimeVariable,
@@ -15,6 +17,7 @@ from .prime import (
 )
 
 from .int32 import (
+    int32factory,
     Int32Tensor,
     Int32Placeholder,
     Int32Variable,
@@ -22,11 +25,25 @@ from .int32 import (
 )
 
 from .int64 import (
+    int64factory,
     Int64Tensor,
     Int64Placeholder,
     Int64Variable,
     Int64Constant
 )
+
+from .fixed import (
+    _validate_fixedpoint_config,
+    fixed100_ni,
+    fixed100_i,
+    fixed64_ni,
+    fixed64_i
+)
+
+_validate_fixedpoint_config(fixed100_ni, int100factory)
+_validate_fixedpoint_config(fixed100_i, int100factory)
+_validate_fixedpoint_config(fixed64_ni, int64factory)
+_validate_fixedpoint_config(fixed64_i, int64factory)
 
 __all__ = [
     'Int100Constant',

--- a/tensorflow_encrypted/tensor/__init__.py
+++ b/tensorflow_encrypted/tensor/__init__.py
@@ -38,10 +38,10 @@ from .fixed import (
     fixed64_ni,
 )
 
-_validate_fixedpoint_config(fixed100, int100factory)
-_validate_fixedpoint_config(fixed100_ni, int100factory)
-_validate_fixedpoint_config(fixed64, int64factory)
-_validate_fixedpoint_config(fixed64_ni, int64factory)
+assert _validate_fixedpoint_config(fixed100, int100factory)
+assert _validate_fixedpoint_config(fixed100_ni, int100factory)
+assert _validate_fixedpoint_config(fixed64, int64factory)
+assert _validate_fixedpoint_config(fixed64_ni, int64factory)
 
 __all__ = [
     'Int100Constant',

--- a/tensorflow_encrypted/tensor/__init__.py
+++ b/tensorflow_encrypted/tensor/__init__.py
@@ -9,7 +9,6 @@ from .int100 import (
 )
 
 from .prime import (
-    PrimeFactory,
     PrimeTensor,
     PrimePlaceholder,
     PrimeVariable,
@@ -17,7 +16,6 @@ from .prime import (
 )
 
 from .int32 import (
-    int32factory,
     Int32Tensor,
     Int32Placeholder,
     Int32Variable,
@@ -34,16 +32,16 @@ from .int64 import (
 
 from .fixed import (
     _validate_fixedpoint_config,
+    fixed100,
     fixed100_ni,
-    fixed100_i,
+    fixed64,
     fixed64_ni,
-    fixed64_i
 )
 
+_validate_fixedpoint_config(fixed100, int100factory)
 _validate_fixedpoint_config(fixed100_ni, int100factory)
-_validate_fixedpoint_config(fixed100_i, int100factory)
+_validate_fixedpoint_config(fixed64, int64factory)
 _validate_fixedpoint_config(fixed64_ni, int64factory)
-_validate_fixedpoint_config(fixed64_i, int64factory)
 
 __all__ = [
     'Int100Constant',

--- a/tensorflow_encrypted/tensor/fixed.py
+++ b/tensorflow_encrypted/tensor/fixed.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from math import ceil, log2
 
-from .factory import AbstractFactory, AbstractTensor, AbstractConstant, AbstractVariable, AbstractPlaceholder
+from .factory import AbstractFactory
 
 
 # NOTE the assumption in encoding/decoding is that encoded numbers will fit into signed int32
@@ -41,6 +41,15 @@ class FixedpointConfig:
         return self.scaling_base ** self.precision_fractional
 
 
+fixed100 = FixedpointConfig(
+    scaling_base=2,
+    precision_integral=14,
+    precision_fractional=16,
+    matmul_threshold=1024,
+    truncation_gap=40,
+    use_noninteractive_truncation=False,
+)
+
 fixed100_ni = FixedpointConfig(
     scaling_base=2,
     precision_integral=14,
@@ -50,16 +59,16 @@ fixed100_ni = FixedpointConfig(
     use_noninteractive_truncation=True,
 )
 
-fixed100_i = FixedpointConfig(
-    scaling_base=2,
-    precision_integral=14,
-    precision_fractional=16,
-    matmul_threshold=1024,
-    truncation_gap=40,
+# TODO[Morten] make sure values in int64 configs make sense
+
+fixed64 = FixedpointConfig(
+    scaling_base=3,
+    precision_integral=7,
+    precision_fractional=8,
+    matmul_threshold=256,
+    truncation_gap=20,
     use_noninteractive_truncation=False,
 )
-
-# TODO[Morten] make sure values in int32 and int64 configs make sense
 
 fixed64_ni = FixedpointConfig(
     scaling_base=2,
@@ -70,14 +79,6 @@ fixed64_ni = FixedpointConfig(
     use_noninteractive_truncation=True,
 )
 
-fixed64_i = FixedpointConfig(
-    scaling_base=3,
-    precision_integral=7,
-    precision_fractional=8,
-    matmul_threshold=256,
-    truncation_gap=20,
-    use_noninteractive_truncation=False,
-)
 
 def _validate_fixedpoint_config(config: FixedpointConfig, tensor_factory: AbstractFactory):
 

--- a/tensorflow_encrypted/tensor/fixed.py
+++ b/tensorflow_encrypted/tensor/fixed.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import
+
+from math import ceil, log2
+
+from .factory import AbstractFactory, AbstractTensor, AbstractConstant, AbstractVariable, AbstractPlaceholder
+
+
+# NOTE the assumption in encoding/decoding is that encoded numbers will fit into signed int32
+class FixedpointConfig:
+
+    def __init__(
+        self,
+        scaling_base: int,
+        precision_integral: int,
+        precision_fractional: int,
+        matmul_threshold: int,
+        truncation_gap: int,
+        use_noninteractive_truncation: bool,
+    ) -> None:
+        self.scaling_base = scaling_base
+        self.precision_integral = precision_integral
+        self.precision_fractional = precision_fractional
+        self.matmul_threshold = matmul_threshold
+        self.truncation_gap = truncation_gap
+        self.use_noninteractive_truncation = use_noninteractive_truncation
+
+    @property
+    def bound_single_precision(self) -> int:
+        return self.scaling_base ** (self.precision_integral + self.precision_fractional)
+
+    @property
+    def bound_double_precision(self) -> int:
+        return self.scaling_base ** (self.precision_integral + 2 * self.precision_fractional)
+
+    @property
+    def bound_intermediate_results(self) -> int:
+        return self.bound_double_precision * self.matmul_threshold
+
+    @property
+    def scaling_factor(self) -> int:
+        return self.scaling_base ** self.precision_fractional
+
+
+fixed100_ni = FixedpointConfig(
+    scaling_base=2,
+    precision_integral=14,
+    precision_fractional=16,
+    matmul_threshold=1024,
+    truncation_gap=20,
+    use_noninteractive_truncation=True,
+)
+
+fixed100_i = FixedpointConfig(
+    scaling_base=2,
+    precision_integral=14,
+    precision_fractional=16,
+    matmul_threshold=1024,
+    truncation_gap=40,
+    use_noninteractive_truncation=False,
+)
+
+# TODO[Morten] make sure values in int32 and int64 configs make sense
+
+fixed64_ni = FixedpointConfig(
+    scaling_base=2,
+    precision_integral=10,
+    precision_fractional=13,
+    matmul_threshold=256,
+    truncation_gap=20,
+    use_noninteractive_truncation=True,
+)
+
+fixed64_i = FixedpointConfig(
+    scaling_base=3,
+    precision_integral=7,
+    precision_fractional=8,
+    matmul_threshold=256,
+    truncation_gap=20,
+    use_noninteractive_truncation=False,
+)
+
+def _validate_fixedpoint_config(config: FixedpointConfig, tensor_factory: AbstractFactory):
+
+    if ceil(log2(config.bound_single_precision)) > 31:
+        print("WARNING: Plaintext values won't fit in 32bit tensors")
+
+    if ceil(log2(config.bound_single_precision)) > 63:
+        print("WARNING: Plaintext values won't fit in 64bit values")
+
+    if ceil(log2(config.bound_double_precision)) + config.truncation_gap >= log2(tensor_factory.modulus):
+        print("WARNING: Modulus is too small for truncation")
+
+    # TODO[Morten] test for intermediate size wrt native type
+
+    # TODO[Morten] in decoding we assume that x + bound fits within the native type of the backing tensor
+
+    # TODO[Morten] truncation gap is statistical security for interactive truncation; write assertions

--- a/tensorflow_encrypted/tensor/fixed.py
+++ b/tensorflow_encrypted/tensor/fixed.py
@@ -80,19 +80,26 @@ fixed64_ni = FixedpointConfig(
 )
 
 
-def _validate_fixedpoint_config(config: FixedpointConfig, tensor_factory: AbstractFactory):
+def _validate_fixedpoint_config(config: FixedpointConfig, tensor_factory: AbstractFactory) -> bool:
+
+    no_issues = True
 
     if ceil(log2(config.bound_single_precision)) > 31:
         print("WARNING: Plaintext values won't fit in 32bit tensors")
+        no_issues = False
 
     if ceil(log2(config.bound_single_precision)) > 63:
         print("WARNING: Plaintext values won't fit in 64bit values")
+        no_issues = False
 
     if ceil(log2(config.bound_double_precision)) + config.truncation_gap >= log2(tensor_factory.modulus):
         print("WARNING: Modulus is too small for truncation")
+        no_issues = False
 
     # TODO[Morten] test for intermediate size wrt native type
 
     # TODO[Morten] in decoding we assume that x + bound fits within the native type of the backing tensor
 
     # TODO[Morten] truncation gap is statistical security for interactive truncation; write assertions
+
+    return no_issues

--- a/tensorflow_encrypted/tensor/helpers.py
+++ b/tensorflow_encrypted/tensor/helpers.py
@@ -17,7 +17,8 @@ def gcd(a: int, b: int) -> int:
 
 
 def inverse(a: int, m: int) -> int:
-    _, b, _ = egcd(a, m)
+    g, b, _ = egcd(a, m)
+    assert g == 1
     return b % m
 
 

--- a/tensorflow_encrypted/tensor/int100.py
+++ b/tensorflow_encrypted/tensor/int100.py
@@ -208,13 +208,28 @@ class Int100Tensor(AbstractTensor):
         raise TypeError("Unsupported type {}".format(type(x)))
 
     def __add__(self, other) -> 'Int100Tensor':
-        return self.add(other)
+        x, y = Int100Tensor.lift(self), Int100Tensor.lift(other)
+        return x.add(y)
+
+    def __radd__(self, other) -> 'Int100Tensor':
+        x, y = Int100Tensor.lift(self), Int100Tensor.lift(other)
+        return x.add(y)
 
     def __sub__(self, other) -> 'Int100Tensor':
-        return self.sub(other)
+        x, y = Int100Tensor.lift(self), Int100Tensor.lift(other)
+        return x.sub(y)
+
+    def __rsub__(self, other) -> 'Int100Tensor':
+        x, y = Int100Tensor.lift(self), Int100Tensor.lift(other)
+        return x.sub(y)
 
     def __mul__(self, other) -> 'Int100Tensor':
-        return self.mul(other)
+        x, y = Int100Tensor.lift(self), Int100Tensor.lift(other)
+        return x.mul(y)
+
+    def __rmul__(self, other) -> 'Int100Tensor':
+        x, y = Int100Tensor.lift(self), Int100Tensor.lift(other)
+        return x.mul(y)
 
     def __mod__(self, k) -> 'Int100Tensor':
         return self.mod(k)
@@ -295,6 +310,11 @@ class Int100Tensor(AbstractTensor):
     def negative(self) -> 'Int100Tensor':
         # TODO[Morten] there's probably a more efficient way
         return int100factory.zero() - self
+
+    def right_shift(self, bitlength):
+        factor = 2**bitlength
+        factor_inverse = inverse(factor, self.factory.modulus)
+        return (self - (self % factor)) * factor_inverse
 
 
 class Int100Constant(Int100Tensor, AbstractConstant):

--- a/tensorflow_encrypted/tensor/int100.py
+++ b/tensorflow_encrypted/tensor/int100.py
@@ -318,10 +318,13 @@ class Int100Tensor(AbstractTensor):
         # TODO[Morten] there's probably a more efficient way
         return int100factory.zero() - self
 
-    def right_shift(self, bitlength):
-        factor = 2**bitlength
+    def truncate(self, amount, base=2):
+        factor = base**amount
         factor_inverse = inverse(factor, self.factory.modulus)
         return (self - (self % factor)) * factor_inverse
+
+    def right_shift(self, bitlength):
+        return self.truncate(bitlength, 2)
 
 
 class Int100Constant(Int100Tensor, AbstractConstant):

--- a/tensorflow_encrypted/tensor/int100.py
+++ b/tensorflow_encrypted/tensor/int100.py
@@ -279,8 +279,8 @@ class Int100Tensor(AbstractTensor):
 
     def equal(self, other) -> 'Int100Tensor':
         x, y = Int100Tensor.lift(self), Int100Tensor.lift(other)
-        backing = _crt_equal(x.backing, y.backing, x.factory.native_type)
-        return Int100Tensor(backing)
+        out_dtype = x.factory
+        return out_dtype.tensor(_crt_equal(x.backing, y.backing, out_dtype.native_type))
 
     def im2col(self, h_filter, w_filter, padding, strides) -> 'Int100Tensor':
         backing = crt_im2col(self.backing, h_filter, w_filter, padding, strides)

--- a/tensorflow_encrypted/tensor/int32.py
+++ b/tensorflow_encrypted/tensor/int32.py
@@ -171,6 +171,9 @@ class Int32Tensor(AbstractTensor):
         x, y = _lift(self, other)
         return factory.tensor(tf.cast(tf.equal(x.value, y.value), dtype=tf.int32))
 
+    def right_shift(self, bitlength):
+        return int32factory.tensor(tf.bitwise.right_shift(self.value, bitlength))
+
 
 class Int32Constant(Int32Tensor, AbstractConstant):
 

--- a/tensorflow_encrypted/tensor/int64.py
+++ b/tensorflow_encrypted/tensor/int64.py
@@ -206,6 +206,9 @@ class Int64Tensor(AbstractTensor):
     def squeeze(self, axis: Optional[List[int]]=None) -> 'Int64Tensor':
         return Int64Tensor(tf.squeeze(self.value, axis=axis))
 
+    def negative(self) -> 'Int64Tensor':
+        return Int64Tensor(tf.negative(self.value))
+
 
 class Int64Constant(Int64Tensor, AbstractConstant):
 

--- a/tensorflow_encrypted/tensor/int64.py
+++ b/tensorflow_encrypted/tensor/int64.py
@@ -5,6 +5,7 @@ import numpy as np
 import tensorflow as tf
 
 from .factory import AbstractFactory, AbstractTensor, AbstractVariable, AbstractConstant, AbstractPlaceholder
+from .helpers import inverse
 from .shared import binarize, conv2d, im2col
 from ..types import Slice, Ellipse
 
@@ -196,6 +197,14 @@ class Int64Tensor(AbstractTensor):
     def equal(self, other, factory: AbstractFactory=int64factory) -> 'AbstractTensor':
         x, y = _lift(self, other)
         return factory.tensor(tf.cast(tf.equal(x.value, y.value), dtype=factory.native_type))
+
+    def truncate(self, amount, base=2) -> 'Int64Tensor':
+        if base == 2:
+            return self.right_shift(amount)
+        else:
+            factor = base**amount
+            factor_inverse = inverse(factor, self.factory.modulus)
+            return (self - (self % factor)) * factor_inverse
 
     def right_shift(self, bitlength) -> 'Int64Tensor':
         return Int64Tensor(tf.bitwise.right_shift(self.value, bitlength))

--- a/tensorflow_encrypted/tensor/int64.py
+++ b/tensorflow_encrypted/tensor/int64.py
@@ -59,7 +59,12 @@ class Int64Factory(AbstractFactory):
         return tf.int64
 
     def sample_uniform(self, shape: List[int]) -> 'Int64Tensor':
-        value = tf.random_uniform(shape=shape, dtype=tf.int64, minval=tf.int64.min, maxval=tf.int64.max)
+        value = tf.random_uniform(shape=shape, dtype=self.native_type, minval=tf.int64.min, maxval=tf.int64.max)
+        return Int64Tensor(value)
+
+    def sample_bounded(self, shape: List[int], bitlength: int) -> 'Int64Tensor':
+        # TODO[Morten] verify that uses of this work for signed integers
+        value = tf.random_uniform(shape=shape, dtype=self.native_type, minval=0, maxval=2**bitlength)
         return Int64Tensor(value)
 
     def stack(self, xs: List['Int64Tensor'], axis: int = 0) -> 'Int64Tensor':

--- a/tensorflow_encrypted/tensor/prime.py
+++ b/tensorflow_encrypted/tensor/prime.py
@@ -9,9 +9,6 @@ from .factory import AbstractFactory, AbstractTensor, AbstractConstant, Abstract
 from .shared import binarize
 
 
-INT_TYPE = tf.int32
-
-
 class PrimeTensor(AbstractTensor):
 
     def __init__(self, value: Union[np.ndarray, tf.Tensor], factory: 'PrimeFactory') -> None:
@@ -134,7 +131,7 @@ def _lift(x, y) -> Tuple[PrimeTensor, PrimeTensor]:
 class PrimeConstant(PrimeTensor, AbstractConstant):
 
     def __init__(self, value: Union[tf.Tensor, np.ndarray], factory) -> None:
-        v = tf.constant(value, dtype=INT_TYPE)
+        v = tf.constant(value, dtype=factory.native_type)
         super(PrimeConstant, self).__init__(v, factory)
 
     def __repr__(self) -> str:
@@ -144,7 +141,7 @@ class PrimeConstant(PrimeTensor, AbstractConstant):
 class PrimePlaceholder(PrimeTensor, AbstractPlaceholder):
 
     def __init__(self, shape: List[int], factory) -> None:
-        placeholder = tf.placeholder(INT_TYPE, shape=shape)
+        placeholder = tf.placeholder(factory.native_type, shape=shape)
         super(PrimePlaceholder, self).__init__(placeholder, factory)
         self.placeholder = placeholder
 
@@ -165,7 +162,7 @@ class PrimePlaceholder(PrimeTensor, AbstractPlaceholder):
 class PrimeVariable(PrimeTensor, AbstractVariable):
 
     def __init__(self, initial_value: Union[tf.Tensor, np.ndarray], factory) -> None:
-        self.variable = tf.Variable(initial_value, dtype=INT_TYPE, trainable=False)
+        self.variable = tf.Variable(initial_value, dtype=factory.native_type, trainable=False)
         self.initializer = self.variable.initializer
         super(PrimeVariable, self).__init__(self.variable.read_value(), factory)
 

--- a/tests/test_batchnorm.py
+++ b/tests/test_batchnorm.py
@@ -55,7 +55,7 @@ class TestBatchnorm(unittest.TestCase):
 
                 out_tensorflow = sess.run(batchnorm_out_tf)
 
-                np.testing.assert_array_almost_equal(out_pond, out_tensorflow, decimal=3)
+                np.testing.assert_array_almost_equal(out_pond, out_tensorflow, decimal=1)
 
 
 if __name__ == '__main__':

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -21,14 +21,8 @@ class TestConv2D(unittest.TestCase):
         filter_shape = (h_filter, w_filter, channels_in, channels_out)
         filter_values = np.random.normal(size=filter_shape)
 
-        config = tfe.LocalConfig([
-            'server0',
-            'server1',
-            'crypto_producer'
-        ])
-
         # convolution pond
-        with tfe.protocol.Pond(*config.get_players('server0, server1, crypto_producer')) as prot:
+        with tfe.protocol.Pond() as prot:
 
             conv_input = prot.define_private_variable(input_conv)
             conv_layer = tfe.layers.Conv2D(input_shape, filter_shape, strides=2)
@@ -59,7 +53,7 @@ class TestConv2D(unittest.TestCase):
             sess.run(tf.global_variables_initializer())
             out_tensorflow = sess.run(conv_out_tf).transpose(0, 3, 1, 2)
 
-        np.testing.assert_array_almost_equal(out_pond, out_tensorflow, decimal=3)
+        np.testing.assert_allclose(out_pond, out_tensorflow, atol=0.01)
 
     def test_backward(self):
         pass

--- a/tests/test_int100_tensor.py
+++ b/tests/test_int100_tensor.py
@@ -17,8 +17,7 @@ class TestInt100Tensor(unittest.TestCase):
         with tfe.protocol.Pond(
             None,
             tensor_factory=int100factory,
-            use_noninteractive_truncation=True,
-            verify_precision=True
+            use_noninteractive_truncation=True
         ) as prot:
 
             x = prot.define_private_variable(np.array([2, 2]), apply_scaling=False)

--- a/tests/test_int100_tensor.py
+++ b/tests/test_int100_tensor.py
@@ -4,7 +4,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
 
-from tensorflow_encrypted.tensor.int100 import int100factory
+from tensorflow_encrypted.tensor import int100factory, fixed100_ni
 
 
 class TestInt100Tensor(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestInt100Tensor(unittest.TestCase):
         with tfe.protocol.Pond(
             None,
             tensor_factory=int100factory,
-            use_noninteractive_truncation=True
+            fixedpoint_config=fixed100_ni,
         ) as prot:
 
             x = prot.define_private_variable(np.array([2, 2]), apply_scaling=False)

--- a/tests/test_int32_tensor.py
+++ b/tests/test_int32_tensor.py
@@ -2,8 +2,7 @@ import unittest
 
 import numpy as np
 import tensorflow as tf
-import tensorflow_encrypted as tfe
-from tensorflow_encrypted.tensor.int32 import Int32Factory, Int32Tensor
+from tensorflow_encrypted.tensor.int32 import Int32Tensor
 
 
 class TestInt32Tensor(unittest.TestCase):

--- a/tests/test_int32_tensor.py
+++ b/tests/test_int32_tensor.py
@@ -10,23 +10,6 @@ class TestInt32Tensor(unittest.TestCase):
     def setUp(self):
         tf.reset_default_graph()
 
-    def test_pond(self) -> None:
-
-        with tfe.protocol.Pond(
-            tensor_factory=Int32Factory(),
-            use_noninteractive_truncation=True
-        ) as prot:
-
-            x = prot.define_private_variable(np.array([2, 2]), apply_scaling=False)
-            y = prot.define_public_variable(np.array([2, 2]), apply_scaling=False)
-
-            z = x * y
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-                out = sess.run(z.reveal())
-                np.testing.assert_array_almost_equal(out, [4, 4], decimal=3)
-
     def test_binarize(self) -> None:
         x = Int32Tensor(tf.constant([
             2**32 + 3,  # == 3

--- a/tests/test_int32_tensor.py
+++ b/tests/test_int32_tensor.py
@@ -11,8 +11,12 @@ class TestInt32Tensor(unittest.TestCase):
         tf.reset_default_graph()
 
     def test_pond(self) -> None:
-        with tfe.protocol.Pond(tensor_factory=Int32Factory(), use_noninteractive_truncation=True,
-                               verify_precision=False) as prot:
+
+        with tfe.protocol.Pond(
+            tensor_factory=Int32Factory(),
+            use_noninteractive_truncation=True
+        ) as prot:
+
             x = prot.define_private_variable(np.array([2, 2]), apply_scaling=False)
             y = prot.define_public_variable(np.array([2, 2]), apply_scaling=False)
 

--- a/tests/test_int64_tensor.py
+++ b/tests/test_int64_tensor.py
@@ -11,15 +11,12 @@ class TestInt64Tensor(unittest.TestCase):
         tf.reset_default_graph()
 
     def test_pond(self) -> None:
-        config = tfe.LocalConfig([
-            'server0',
-            'server1',
-            'crypto_producer'
-        ])
 
-        with tfe.protocol.Pond(*config.get_players('server0, server1, crypto_producer'),
-                               tensor_factory=Int64Factory(), use_noninteractive_truncation=True,
-                               verify_precision=False) as prot:
+        with tfe.protocol.Pond(
+            tensor_factory=Int64Factory(),
+            use_noninteractive_truncation=True,
+        ) as prot:
+
             x = prot.define_private_variable(np.array([2, 2]), apply_scaling=False)
             y = prot.define_public_variable(np.array([2, 2]), apply_scaling=False)
 

--- a/tests/test_int64_tensor.py
+++ b/tests/test_int64_tensor.py
@@ -3,7 +3,8 @@ import unittest
 import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
-from tensorflow_encrypted.tensor.int64 import Int64Factory, Int64Tensor
+
+from tensorflow_encrypted.tensor import int64factory, fixed64_i
 
 
 class TestInt64Tensor(unittest.TestCase):
@@ -13,8 +14,8 @@ class TestInt64Tensor(unittest.TestCase):
     def test_pond(self) -> None:
 
         with tfe.protocol.Pond(
-            tensor_factory=Int64Factory(),
-            use_noninteractive_truncation=True,
+            tensor_factory=int64factory,
+            fixedpoint_config=fixed64_i,
         ) as prot:
 
             x = prot.define_private_variable(np.array([2, 2]), apply_scaling=False)
@@ -28,7 +29,7 @@ class TestInt64Tensor(unittest.TestCase):
                 np.testing.assert_array_almost_equal(out, [4, 4], decimal=3)
 
     def test_binarize(self) -> None:
-        x = Int64Tensor(tf.constant([
+        x = int64factory.tensor(tf.constant([
             2**62 + 3,
             2**63 - 1,
             2**63 - 2,
@@ -55,7 +56,7 @@ class TestInt64Tensor(unittest.TestCase):
 
     def test_random_binarize(self) -> None:
         input = np.random.uniform(low=2**63 + 1, high=2**63 - 1, size=2000).astype(np.int64).tolist()
-        x = Int64Tensor(tf.constant(input, dtype=tf.int64))
+        x = int64factory.tensor(tf.constant(input, dtype=tf.int64))
 
         y = x.to_bits()
 

--- a/tests/test_int64_tensor.py
+++ b/tests/test_int64_tensor.py
@@ -4,7 +4,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
 
-from tensorflow_encrypted.tensor import int64factory, fixed64_i
+from tensorflow_encrypted.tensor import int64factory, fixed64
 
 
 class TestInt64Tensor(unittest.TestCase):
@@ -15,7 +15,7 @@ class TestInt64Tensor(unittest.TestCase):
 
         with tfe.protocol.Pond(
             tensor_factory=int64factory,
-            fixedpoint_config=fixed64_i,
+            fixedpoint_config=fixed64,
         ) as prot:
 
             x = prot.define_private_variable(np.array([2, 2]), apply_scaling=False)

--- a/tests/test_lsb.py
+++ b/tests/test_lsb.py
@@ -26,7 +26,6 @@ class TestLSB(unittest.TestCase):
         with tfe.protocol.SecureNN(
             tensor_factory=tensor_factory,
             prime_factory=prime_factory,
-            verify_precision=False
         ) as prot:
 
             x_in = prot.define_private_variable(self.x, apply_scaling=False, name='test_lsb_input')

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -10,13 +10,9 @@ class TestMatMul(unittest.TestCase):
         tf.reset_default_graph()
 
     def test_matmul(self) -> None:
-        config = tfe.LocalConfig([
-            'server_0',
-            'server_1',
-            'crypto_producer'
-        ])
 
-        with tfe.protocol.Pond(*config.get_players('server_0, server_1, crypto_producer')) as prot:
+        with tfe.protocol.Pond() as prot:
+
             input_shape = [4, 5]
             input = np.random.normal(size=input_shape)
 
@@ -48,13 +44,9 @@ class TestMatMul(unittest.TestCase):
         np.testing.assert_array_almost_equal(out_pond, out_tensorflow, decimal=2)
 
     def test_big_middle_matmul(self) -> None:
-        config = tfe.LocalConfig([
-            'server_0',
-            'server_1',
-            'crypto_producer'
-        ])
 
-        with tfe.protocol.Pond(*config.get_players('server_0, server_1, crypto_producer')) as prot:
+        with tfe.protocol.Pond() as prot:
+
             input_shape = [64, 4500]
             input = np.random.normal(size=input_shape)
 
@@ -83,7 +75,7 @@ class TestMatMul(unittest.TestCase):
             sess.run(tf.global_variables_initializer())
             out_tensorflow = sess.run(out)
 
-        np.testing.assert_array_almost_equal(out_pond, out_tensorflow, decimal=2)
+        np.testing.assert_allclose(out_pond, out_tensorflow, atol=.3)
 
 
 if __name__ == '__main__':

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -75,7 +75,7 @@ class TestMatMul(unittest.TestCase):
             sess.run(tf.global_variables_initializer())
             out_tensorflow = sess.run(out)
 
-        np.testing.assert_allclose(out_pond, out_tensorflow, atol=.3)
+        np.testing.assert_allclose(out_pond, out_tensorflow, atol=.1)
 
 
 if __name__ == '__main__':

--- a/tests/test_maxpool2d.py
+++ b/tests/test_maxpool2d.py
@@ -1,16 +1,16 @@
 import unittest
+
 import tensorflow_encrypted as tfe
 import tensorflow as tf
 import numpy as np
+
 from tensorflow_encrypted.layers.pooling import MaxPooling2D
 
 
 class TestMaxPooling2D(unittest.TestCase):
     def test_maxpool2d(self):
-        with tfe.protocol.SecureNN(
-            use_noninteractive_truncation=True,
-            verify_precision=False
-        ) as prot:
+        with tfe.protocol.SecureNN() as prot:
+
             input = np.array([[[[1, 2, 3, 4],
                                 [3, 2, 4, 1],
                                 [1, 2, 3, 4],

--- a/tests/test_pond_equal.py
+++ b/tests/test_pond_equal.py
@@ -14,12 +14,9 @@ class TestPondPublicEqual(unittest.TestCase):
 
         expected = np.array([1, 0, 1, 0])
 
-        with tfe.protocol.Pond(
-            tensor_factory=int32factory,
-            use_noninteractive_truncation=True,
-        ) as prot:
+        with tfe.protocol.Pond() as prot:
 
-            x_raw = int32factory.constant(np.array([100, 200, 100, 300]))
+            x_raw = prot.tensor_factory.constant(np.array([100, 200, 100, 300]))
             x = PondPublicTensor(prot, value_on_0=x_raw, value_on_1=x_raw, is_scaled=False)
 
             res = prot.equal(x, 100)

--- a/tests/test_pond_equal.py
+++ b/tests/test_pond_equal.py
@@ -5,7 +5,6 @@ import tensorflow_encrypted as tfe
 import numpy as np
 
 from tensorflow_encrypted.protocol.pond import PondPublicTensor
-from tensorflow_encrypted.tensor.int32 import int32factory
 
 
 class TestPondPublicEqual(unittest.TestCase):

--- a/tests/test_pond_equal.py
+++ b/tests/test_pond_equal.py
@@ -17,7 +17,6 @@ class TestPondPublicEqual(unittest.TestCase):
         with tfe.protocol.Pond(
             tensor_factory=int32factory,
             use_noninteractive_truncation=True,
-            verify_precision=False
         ) as prot:
 
             x_raw = int32factory.constant(np.array([100, 200, 100, 300]))

--- a/tests/test_private_compare.py
+++ b/tests/test_private_compare.py
@@ -1,44 +1,10 @@
 import unittest
-import random
 
 import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
-from tensorflow_encrypted.tensor.prime import PrimeFactory
 from tensorflow_encrypted.protocol.pond import PondPrivateTensor, PondPublicTensor
 from tensorflow_encrypted.protocol.securenn import _private_compare
-
-bits = 32
-Q = 2 ** bits
-
-
-# Hacky using numpy until we have binarize in PrimeTensor
-def binarize(tensor):
-    """Computes bit decomposition of tensor
-     tensor: ndarray of shape (x0, ..., xn)
-    returns: a binary tensor of shape (x0, ..., xn, bits) equivalent to tensor
-    """
-    bitwidths = np.arange(bits, dtype=np.int32)
-    for i in range(len(tensor.shape)):
-        bitwidths = np.expand_dims(bitwidths, 0)
-    tensor = np.expand_dims(tensor, -1)
-    tensor = np.right_shift(tensor, bitwidths) & 1
-    return tensor
-
-
-def sample_random_tensor(shape, modulus=Q):
-    if len(shape) >= 1:
-        n = np.prod(shape)
-    else:
-        n = 1
-    values = [random.randrange(modulus) for _ in range(n)]
-    return np.array(values, dtype=np.int64).reshape(shape)
-
-
-def share(secrets, modulus=Q):
-    shares0 = sample_random_tensor(secrets.shape, modulus)
-    shares1 = (secrets - shares0)  # % modulus
-    return shares0, shares1
 
 
 class TestPrivateCompare(unittest.TestCase):
@@ -80,35 +46,31 @@ class TestPrivateCompare(unittest.TestCase):
 
         expected = np.bitwise_xor(x > r, beta.astype(bool)).astype(np.int32)
 
-        bit_dtype = PrimeFactory(37)
-        # val_dtype = int32factory
-        val_dtype = bit_dtype
+        prot = tfe.protocol.SecureNN()
 
-        prot = tfe.protocol.SecureNN(
-            tensor_factory=val_dtype,
-            prime_factory=bit_dtype,
-        )
+        bit_dtype = prot.prime_factory
+        val_dtype = prot.tensor_factory
 
         res = _private_compare(
             prot,
             x_bits=PondPrivateTensor(
                 prot,
-                *prot._share(bit_dtype.tensor(tf.convert_to_tensor(x)).to_bits()),
+                *prot._share(val_dtype.tensor(tf.convert_to_tensor(x, dtype=val_dtype.native_type)).to_bits(bit_dtype)),
                 False),
             r=PondPublicTensor(
                 prot,
-                val_dtype.tensor(tf.convert_to_tensor(r)),
-                val_dtype.tensor(tf.convert_to_tensor(r)),
+                val_dtype.tensor(tf.convert_to_tensor(r, dtype=val_dtype.native_type)),
+                val_dtype.tensor(tf.convert_to_tensor(r, dtype=val_dtype.native_type)),
                 False),
             beta=PondPublicTensor(
                 prot,
-                bit_dtype.tensor(tf.convert_to_tensor(beta)),
-                bit_dtype.tensor(tf.convert_to_tensor(beta)),
+                bit_dtype.tensor(tf.convert_to_tensor(beta, dtype=bit_dtype.native_type)),
+                bit_dtype.tensor(tf.convert_to_tensor(beta, dtype=bit_dtype.native_type)),
                 False)
         )
 
         with tfe.Session() as sess:
-            actual = sess.run(res.reveal().value_on_0.value)
+            actual = sess.run(res.reveal().value_on_0.to_native())
             np.testing.assert_array_equal(actual, expected)
 
 

--- a/tests/test_private_compare.py
+++ b/tests/test_private_compare.py
@@ -87,7 +87,6 @@ class TestPrivateCompare(unittest.TestCase):
         prot = tfe.protocol.SecureNN(
             tensor_factory=val_dtype,
             prime_factory=bit_dtype,
-            use_noninteractive_truncation=True,
         )
 
         res = _private_compare(

--- a/tests/test_private_compare.py
+++ b/tests/test_private_compare.py
@@ -45,12 +45,6 @@ class TestPrivateCompare(unittest.TestCase):
 
     def test_private(self):
 
-        tfe.set_config(tfe.LocalConfig([
-            'server0',
-            'server1',
-            'crypto_producer'
-        ]))
-
         x = np.array([
             21,
             21,
@@ -94,7 +88,6 @@ class TestPrivateCompare(unittest.TestCase):
             tensor_factory=val_dtype,
             prime_factory=bit_dtype,
             use_noninteractive_truncation=True,
-            verify_precision=False
         )
 
         res = _private_compare(

--- a/tests/test_relu.py
+++ b/tests/test_relu.py
@@ -4,8 +4,6 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
 
-from tensorflow_encrypted.tensor.int64 import int64factory
-# from tensorflow_encrypted.tensor.int100 import int100factory
 from tensorflow_encrypted.layers.activation import Relu
 
 
@@ -17,10 +15,7 @@ class TestRelu(unittest.TestCase):
         input_shape = [4]
         input_relu = np.array([-1.0, -0.5, 0.5, 3.0]).astype(np.float32)
 
-        with tfe.protocol.SecureNN(
-            tensor_factory=int64factory,
-            use_noninteractive_truncation=True,
-        ) as prot:
+        with tfe.protocol.SecureNN() as prot:
 
             tf.reset_default_graph()
 

--- a/tests/test_relu.py
+++ b/tests/test_relu.py
@@ -3,6 +3,9 @@ import unittest
 import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
+
+from tensorflow_encrypted.tensor.int64 import int64factory
+# from tensorflow_encrypted.tensor.int100 import int100factory
 from tensorflow_encrypted.layers.activation import Relu
 
 
@@ -14,8 +17,10 @@ class TestRelu(unittest.TestCase):
         input_shape = [4]
         input_relu = np.array([-1.0, -0.5, 0.5, 3.0]).astype(np.float32)
 
-        # with tfe.protocol.Pond() as prot:
-        with tfe.protocol.SecureNN() as prot:
+        with tfe.protocol.SecureNN(
+            tensor_factory=int64factory,
+            use_noninteractive_truncation=True,
+        ) as prot:
 
             tf.reset_default_graph()
 

--- a/tests/test_select_share.py
+++ b/tests/test_select_share.py
@@ -9,22 +9,16 @@ class TestSelectShare(unittest.TestCase):
 
     def test_selectShare(self):
 
-        config = tfe.LocalConfig([
-            'server0',
-            'server1',
-            'crypto_producer'
-        ])
-
         alice = np.array([1, 1, 1, 1]).astype(np.float32)
         bob = np.array([2, 2, 2, 2]).astype(np.float32)
         bit = np.array([1, 0, 1, 0]).astype(np.float32)
 
         expected = np.array([2, 1, 2, 1]).astype(np.float32)
 
-        with tfe.protocol.SecureNN(*config.get_players('server0, server1, crypto_producer')) as prot:
-            alice_input = prot.define_private_variable(alice)
-            bob_input = prot.define_private_variable(bob)
-            bit_input = prot.define_private_variable(bit)
+        with tfe.protocol.SecureNN() as prot:
+            alice_input = prot.define_private_variable(alice, apply_scaling=True)
+            bob_input = prot.define_private_variable(bob, apply_scaling=True)
+            bit_input = prot.define_private_variable(bit, apply_scaling=False)
 
             select = prot.select(bit_input, alice_input, bob_input)
 
@@ -32,7 +26,7 @@ class TestSelectShare(unittest.TestCase):
                 sess.run(tf.global_variables_initializer())
                 chosen = sess.run(select.reveal())
 
-                assert(np.array_equal(expected, chosen))
+                np.testing.assert_equal(expected, chosen)
 
 
 if __name__ == '__main__':

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -11,43 +11,28 @@ class TestTruncate(unittest.TestCase):
 
     def test_interactive_truncate(self):
 
-        config = tfe.LocalConfig([
-            'server0',
-            'server1',
-            'crypto_producer'
-        ])
-
-        server0, server1, cp = config.get_players('server0, server1, crypto_producer')
-
         prot = tfe.protocol.Pond(
-            server0, server1, cp,
             use_noninteractive_truncation=False
         )
 
-        with tfe.Session() as sess:
+        # TODO[Morten] remove this condition
+        if prot.tensor_factory not in [tfe.tensor.int64.int64factory]:
 
-            expected = np.array([12345.6789])
+            with tfe.Session() as sess:
 
-            w = prot.define_private_variable(expected * (2**16))  # double precision
-            v = prot.truncate(w)  # single precision
+                expected = np.array([12345.6789])
 
-            sess.run(tf.global_variables_initializer())
-            actual = sess.run(v.reveal(), tag='foo')
+                w = prot.define_private_variable(expected * prot.fixedpoint_config.scaling_factor)  # double precision
+                v = prot.truncate(w)  # single precision
 
-            assert np.isclose(actual, expected).all(), actual
+                sess.run(tf.global_variables_initializer())
+                actual = sess.run(v.reveal(), tag='foo')
+
+                np.testing.assert_allclose(actual, expected)
 
     def test_noninteractive_truncate(self):
 
-        config = tfe.LocalConfig([
-            'server0',
-            'server1',
-            'crypto_producer'
-        ])
-
-        server0, server1, cp = config.get_players('server0, server1, crypto_producer')
-
         prot = tfe.protocol.Pond(
-            server0, server1, cp,
             use_noninteractive_truncation=True
         )
 
@@ -55,13 +40,13 @@ class TestTruncate(unittest.TestCase):
 
             expected = np.array([12345.6789])
 
-            w = prot.define_private_variable(expected * (2**16))  # double precision
+            w = prot.define_private_variable(expected * prot.fixedpoint_config.scaling_factor)  # double precision
             v = prot.truncate(w)  # single precision
 
             sess.run(tf.global_variables_initializer())
             actual = sess.run(v.reveal(), tag='foo')
 
-            assert np.isclose(actual, expected).all(), actual
+            np.testing.assert_allclose(actual, expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -4,7 +4,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_encrypted as tfe
 
-from tensorflow_encrypted.tensor import int100factory, fixed100_i, fixed100_ni
+from tensorflow_encrypted.tensor import int100factory, fixed100, fixed100_ni
 
 
 class TestTruncate(unittest.TestCase):
@@ -15,9 +15,9 @@ class TestTruncate(unittest.TestCase):
 
         prot = tfe.protocol.Pond(
             tensor_factory=int100factory,
-            fixedpoint_config=fixed100_i,
+            fixedpoint_config=fixed100,
         )
-        
+
         with tfe.Session() as sess:
 
             expected = np.array([12345.6789])


### PR DESCRIPTION
Adds support for int64 backing tensors and sets it as default when TensorFlow supports it

Closes #79 