### PR TITLE
Introduce int64 Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.5
 
+ARG TF_WHL_URL="https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp35-cp35m-linux_x86_64.whl"
+
 RUN mkdir -p /usr/src/tf-encrypted \
     && pip install --upgrade pip \
-    && pip install --upgrade tensorflow==1.11.0
+    && pip install --upgrade $TF_WHL_URL
 
 WORKDIR /usr/src/tf-encrypted
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: test
 # ###############################################
 DOCKER_REQUIRED_VERSION=18.
 PYTHON_REQUIRED_VERSION=3.5.
-TENSORFLOW_REQUIRED_VERSION=1.11
+TENSORFLOW_REQUIRED_VERSION=1.9
 SHELL := /bin/bash
 
 CURRENT_DIR=$(shell pwd)
@@ -115,8 +115,10 @@ endif
 # Builds a docker image for tf-encrypted that can be used to deploy and
 # test.
 # ###############################################
+DOCKER_BUILD=docker build -t mortendahl/tf-encrypted:$(1) -f Dockerfile $(2) .
 docker: Dockerfile dockercheck
-	docker build -t mortendahl/tf-encrypted:latest -f Dockerfile .
+	$(call DOCKER_BUILD,latest,)
+	$(call DOCKER_BUILD,latest-int64,--build-arg TF_WHL_URL=https://storage.googleapis.com/dropoutlabs-tensorflow-builds/tensorflow-1.9.0-cp35-cp35m-linux_x86_64.whl)
 
 .PHONY: docker
 
@@ -127,7 +129,7 @@ docker: Dockerfile dockercheck
 # authenticating to docker hub and pushing built docker containers up with the
 # appropriate tags.
 # ###############################################
-DOCKER_TAG=docker tag mortendahl/tf-encrypted:latest mortendahl/tf-encrypted:$(1)
+DOCKER_TAG=docker tag mortendahl/tf-encrypted:$(1) mortendahl/tf-encrypted:$(2)
 DOCKER_PUSH=docker push mortendahl/tf-encrypted:$(1)
 
 docker-logincheck:
@@ -138,13 +140,16 @@ endif
 endif
 
 docker-tag: dockercheck
-	$(call DOCKER_TAG,$(VERSION))
+	$(call DOCKER_TAG,latest,$(VERSION))
+	$(call DOCKER_TAG,latest-int64,$(VERSION)-int64)
 
 docker-push-tag: dockercheck
 	$(call DOCKER_PUSH,$(VERSION))
+	$(call DOCKER_PUSH,$(VERSION)-int64)
 
 docker-push-latest: dockercheck
 	$(call DOCKER_PUSH,latest)
+	$(call DOCKER_PUSH,latest-int64)
 
 # Rely on DOCKER_USERNAME and DOCKER_PASSWORD being set inside CI or equivalent
 # environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ pycparser==2.18
 requests==2.19.1
 s3transfer==0.1.13
 six==1.11.0
-tensorboard==1.11.0
-tensorflow==1.11.0
+tensorboard==1.9.0
+tensorflow==1.9.0
 termcolor==1.1.0
 typed-ast==1.1.0
 urllib3==1.23

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires=">=3.5",
     install_requires=[
-        "tensorflow>=1.11.0",
+        "tensorflow>=1.9.0",
         "numpy>=1.14.0"
     ],
     extra_requires={
-        "tf": ["tensorflow>=1.11.0"]
+        "tf": ["tensorflow>=1.9.0"]
     },
     license="Apache License 2.0",
     url="https://github.com/mortendahl/tf-encrypted",


### PR DESCRIPTION
We now publish two different containers `mortendahl/tf-encrypted:$(VERSION)`
and `mortendahl/tf-encrypted:$(VERSION)-int64`. The latter container
uses a custom build of tensorflow 1.9.0 that contains support for int64
matrix multiplications.

We now have moved backed to requiring tensorflow 1.9.0 or greater!