### PR TITLE
Fix CircleCI Tag Filtering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ workflows:
               # In order for the 'deploy' job to run, we must first kick off
               # the build job on all tags. By default, Circle CI only kicks off
               # builds on tags if a filter is defined.
-              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc\.[0-9]+)?)$/
+              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
       - deploy:
           requires:
             - build
@@ -81,4 +81,4 @@ workflows:
             branches:
               only: master
             tags:
-              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc\.[0-9]+)?)$/
+              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/


### PR DESCRIPTION
When we switched to a PEP440 compliant tag format we forgot to update
our Circle CI configuration to look for tags following that format.