### PR TITLE
Typo fix in examples/ files

### DIFF
--- a/examples/mnist/run.py
+++ b/examples/mnist/run.py
@@ -159,7 +159,7 @@ with tfe.Session(target) as sess:
     sess.run(tf.global_variables_initializer(), tag='init')
 
     print("Training")
-    sess.run(tfe.global_caches_updator(), tag='training')
+    sess.run(tfe.global_caches_updater(), tag='training')
 
     for _ in range(5):
         print("Predicting")

--- a/examples/securenn/network_a.py
+++ b/examples/securenn/network_a.py
@@ -163,7 +163,7 @@ with tfe.Session() as sess:
     sess.run(tf.global_variables_initializer(), tag='init')
 
     print("Training")
-    sess.run(tfe.global_caches_updator(), tag='training')
+    sess.run(tfe.global_caches_updater(), tag='training')
 
     for _ in range(5):
         print("Predicting")

--- a/examples/securenn/network_b.py
+++ b/examples/securenn/network_b.py
@@ -204,7 +204,7 @@ with tfe.Session() as sess:
     sess.run(tf.global_variables_initializer(), tag='init')
 
     print("Training")
-    sess.run(tfe.global_caches_updator(), tag='training')
+    sess.run(tfe.global_caches_updater(), tag='training')
 
     for _ in range(5):
         print("Predicting")

--- a/examples/securenn/network_c.py
+++ b/examples/securenn/network_c.py
@@ -210,7 +210,7 @@ with tfe.Session() as sess:
     sess.run(tf.global_variables_initializer(), tag='init')
 
     print("Training")
-    sess.run(tfe.global_caches_updator(), tag='training')
+    sess.run(tfe.global_caches_updater(), tag='training')
 
     for _ in range(5):
         print("Predicting")

--- a/examples/securenn/network_d.py
+++ b/examples/securenn/network_d.py
@@ -194,7 +194,7 @@ with tfe.Session() as sess:
     sess.run(tf.global_variables_initializer(), tag='init')
 
     print("Training")
-    sess.run(tfe.global_caches_updator(), tag='training')
+    sess.run(tfe.global_caches_updater(), tag='training')
 
     for _ in range(5):
         print("Predicting")


### PR DESCRIPTION
#291 fixed a typo in the code ("updator" --> "updater") but did not apply this fix to files in the `examples/` folder.  This PR offers a patch.