### PR TITLE
the cache could still fail for linux builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,26 +22,26 @@ variables:
   restore-cache: &restore-cache
     restore_cache:
       keys:
-        - v2-dependencies-{{ checksum "requirements.txt" }}
+        - v3-dependencies-{{ checksum "requirements.txt" }}
         # fallback to using the latest cache if no exact match is found
-        - v2-dependencies-
+        - v3-dependencies-
   save-cache: &save-cache
     save_cache:
       paths:
         - ./venv
-      key: v2-dependencies-{{ checksum "requirements.txt" }}
+      key: v3-dependencies-{{ checksum "requirements.txt" }}
   restore-cache-mac: &restore-cache-mac
     restore_cache:
       keys:
-        - v2-dependencies-mac2-{{ checksum "requirements.txt" }}
-        - v2-dependencies-mac2-
+        - v3-mac-dependencies-{{ checksum "requirements.txt" }}
+        - v3-mac-dependencies-
   save-cache-mac: &save-cache-mac
     save_cache:
       paths:
         - ./venv
         - ../miniconda3
         - ./Miniconda3-latest-MacOSX-x86_64.sh
-      key: v2-dependencies-mac2-{{ checksum "requirements.txt" }}
+      key: v3-mac-dependencies-{{ checksum "requirements.txt" }}
 
 jobs:
   build:


### PR DESCRIPTION
the cache could still fail for linux builds because too much of the keys for linux and mac were too similar