### PR TITLE
use curl instead of wget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ push: pypi-version-check
 # ###############################################
 
 $(LIBSODIUM_OUT):
-	wget -nc https://github.com/jedisct1/libsodium/archive/$(LIBSODIUM_VER_TAG).tar.gz
+	curl -OL https://github.com/jedisct1/libsodium/archive/$(LIBSODIUM_VER_TAG).tar.gz
 	mkdir -p build
 	tar -xvf $(LIBSODIUM_VER_TAG).tar.gz -C build
 	cd $(LIBSODIUM_DIR) && ./autogen.sh && ./configure --disable-shared --enable-static \


### PR DESCRIPTION
Fixes https://github.com/mortendahl/tf-encrypted/issues/300

We might want to start doing macos builds (not deploys) on every commit to avoid these sort of bugs. I just worry about builds for each commit taking too long and using up all our macos build machines (I think we only have 1 right now).