### PR TITLE
release 0.4.0-rc2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,11 @@ workflows:
               # builds on tags if a filter is defined.
               only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
       - deploy:
+          requires:
+            - build
           filters:
+            branches:
+              only: master
             tags:
               only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
       - deploy-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,11 +144,7 @@ workflows:
               # builds on tags if a filter is defined.
               only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
       - deploy:
-          requires:
-            - build
           filters:
-            branches:
-              only: master
             tags:
               only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
       - deploy-macos:

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ pypi-push: pypi-push-$(PUSHTYPE)
 # The following are meta-rules for building and pushing various different
 # release artifacts to their intended destinations.
 # ###############################################
-push: pypi-version-check
+push:
 	@echo "Attempting to build and push $(VERSION) with push type $(PUSHTYPE) - $(EXACT_TAG)"
 	make docker-push
 	make pypi-push

--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,12 @@ endif
 pypi-push-master: build-all pypicheck pypi-platform-check
 	pip install --upgrade setuptools wheel twine
 	rm -rf dist
+
+ifeq ($(PYPI_PLATFORM),$(DEFAULT_PLATFORM))
 	python setup.py sdist bdist_wheel --plat-name=$(PYPI_PLATFORM)
-	twine upload -u="$(PYPITEST_USERNAME)" -p="$(PYPITEST_PASSWORD)" --repository-url https://test.pypi.org/legacy/ dist/*
+else
+	python setup.py bdist_wheel --plat-name=$(PYPI_PLATFORM)
+endif
 
 pypi-push-release-candidate: releasecheck pypi-version-check pypi-push-master
 	@echo "Attempting to upload to pypi"

--- a/Makefile
+++ b/Makefile
@@ -232,14 +232,15 @@ ifeq (,$(PYPI_PLATFORM))
 PYPI_PLATFORM=$(DEFAULT_PLATFORM)
 endif
 
-pypi-push-master: build-all pypicheck pypi-version-check pypi-platform-check
+pypi-push-master: build-all pypicheck pypi-platform-check
 	pip install --upgrade setuptools wheel twine
 	rm -rf dist
 	python setup.py sdist bdist_wheel --plat-name=$(PYPI_PLATFORM)
+	twine upload -u="$(PYPITEST_USERNAME)" -p="$(PYPITEST_PASSWORD)" --repository-url https://test.pypi.org/legacy/ dist/*
 
-pypi-push-release-candidate: releasecheck pypi-push-master
+pypi-push-release-candidate: releasecheck pypi-version-check pypi-push-master
 	@echo "Attempting to upload to pypi"
-	@PATH=\$PATH:~/.local/bin twine upload -u="$(PYPI_USERNAME)" -p="$(PYPI_PASSWORD)" dist/*
+	twine upload -u="$(PYPI_USERNAME)" -p="$(PYPI_PASSWORD)" dist/*
 
 pypi-push-release: pypi-push-release-candidate
 

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ PYPI_PLATFORM=$(DEFAULT_PLATFORM)
 endif
 
 pypi-push-master: build-all pypicheck pypi-version-check pypi-platform-check
-	pip install --user --upgrade setuptools wheel twine
+	pip install --upgrade setuptools wheel twine
 	rm -rf dist
 	python setup.py sdist bdist_wheel --plat-name=$(PYPI_PLATFORM)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To make use of int64 in the SecureNN protocol you'll need to download a special 
 
 Download for MacOS [here](https://storage.googleapis.com/dropoutlabs-tensorflow-builds/tensorflow-1.12.0-cp35-cp35m-macosx_10_7_x86_64.whl).
 
-Download for Linux [here](https://storage.googleapis.com/dropoutlabs-tensorflow-builds/tensorflow-1.9.0-cp35-cp35m-linux_x86_64.whl).
+Download for Linux [here](https://storage.googleapis.com/dropoutlabs-tensorflow-builds/tensorflow-1.12.0-cp35-cp35m-linux_x86_64.whl).
 
 Now you should just be able to install using pip:
 
@@ -74,7 +74,7 @@ pip install tensorflow-1.9.0-cp35-cp35m-macosx_10_7_x86_64.whl
 **Linux**
 
 ```
-pip install tensorflow-1.9.0-cp35-cp35m-linux_x86_64.whl
+pip install tensorflow-1.12.0-cp35-cp35m-linux_x86_64.whl
 ```
 
 tf-encrypted auto-detects whether int64 support is available or not and uses that by default if so. So no further action will be needed to make use of this cool feature!!

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2018, The tf-encrypted Contributors'
 author = 'The tf-encrypted Contributors'
 
 # The short X.Y version
-version = '0.4.0-rc1'
+version = '0.4.0-rc2'
 # The full version, including alpha/beta/rc tags
-release = '0.4.0-rc1'
+release = '0.4.0-rc2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tf-encrypted",
-    version="0.4.0-rc1",
+    version="0.4.0-rc2",
     packages=setuptools.find_packages(),
     package_data={'tf_encrypted': [
         'operations/secure_random/*.so',


### PR DESCRIPTION
Since circle ci was in a virtual environment and twine was installed for the user it couldn't find the twine package. Remove the --user parameter to twine and just install in the virtual environment.