### PR TITLE
Clean up conversion tests

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -14,8 +14,6 @@ from tensorflow.python.platform import gfile
 from tensorflow.python.framework import graph_util
 from tensorflow.python.framework import graph_io
 
-from .test_pad import run_pad
-
 
 global_filename = ''
 
@@ -30,609 +28,139 @@ class TestConvert(unittest.TestCase):
         logging.debug("Cleaning file: %s" % global_filename)
         os.remove(global_filename)
 
+    @staticmethod
+    def ndarray_input_fn(x):
+        def input_fn():
+            return tf.constant(x)
+        return input_fn
+
+    @staticmethod
+    def _assert_successful_conversion(prot, graph_def, actual, *input_fns, **kwargs):
+        prot.clear_initializers()
+
+        converter = Converter(tfe.get_config(), prot, 'model-provider')
+        x = converter.convert(graph_def, register(), 'input-provider', list(input_fns))
+
+        with tfe.Session() as sess:
+            sess.run(tf.global_variables_initializer())
+            output = sess.run(x.reveal(), tag='reveal')
+
+        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+
+    @staticmethod
+    def _construct_conversion_test(op_name, protocol='Pond', *test_inputs, **kwargs):
+        global global_filename
+        global_filename = '{}.pb'.format(op_name)
+        exporter = globals()['export_{}'.format(op_name)]
+        runner = globals()['run_{}'.format(op_name)]
+
+        path = exporter(global_filename, test_inputs[0].shape, **kwargs)
+        tf.reset_default_graph()
+
+        graph_def = read_graph(path)
+        tf.reset_default_graph()
+
+        actual = runner(*test_inputs, **kwargs)
+        tf.reset_default_graph()
+
+        prot_class = getattr(tfe.protocol, protocol)
+
+        return graph_def, actual, prot_class
+
+    @classmethod
+    def _test_with_ndarray_input_fn(cls, op_name, test_input, protocol='Pond', **kwargs):
+        # Treat this as an example of how to run tests with a particular kind of input
+        graph_def, actual, prot_class = cls._construct_conversion_test(op_name,
+                                                                       test_input,
+                                                                       protocol,
+                                                                       **kwargs)
+        with prot_class() as prot:
+            input_fn = cls.ndarray_input_fn(test_input)
+            cls._assert_successful_conversion(prot, graph_def, actual, input_fn, **kwargs)
+
     def test_cnn_convert(self):
-        tf.reset_default_graph()
+        test_input = np.ones([1, 1, 28, 28])
+        self._test_with_ndarray_input_fn('cnn', 'Pond', test_input)
 
-        global global_filename
-        global_filename = "cnn.pb"
-
-        input_shape = [1, 1, 28, 28]
-
-        path = export_cnn(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_cnn(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
-
-    def test_cnn_NHWC_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "cnn_nhwc.pb"
-
-        input_shape = [1, 28, 28, 1]
-
-        path = export_cnn(global_filename, input_shape, data_format="NHWC")
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_cnn(input_shape, data_format="NHWC")
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = np.ones([1, 28, 28, 1])
+        self._test_with_ndarray_input_fn('cnn', 'Pond', test_input, data_format='NHWC')
 
     def test_matmul_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "matmul.pb"
-
-        input_shape = [1, 28]
-
-        path = export_matmul(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_matmul(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = np.ones([1, 28])
+        self._test_with_ndarray_input_fn('matmul', 'Pond', test_input)
 
     def test_add_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "add.pb"
-
-        input_shape = [28, 1]
-
-        path = export_add(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_add(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = np.ones([28, 1])
+        self._test_with_ndarray_input_fn('add', 'Pond', test_input)
 
     def test_transpose_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "transpose.pb"
-
-        input_shape = [1, 2, 3, 4]
-
-        path = export_transpose(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_transpose(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = np.ones([1, 2, 3, 4])
+        self._test_with_ndarray_input_fn('transpose', 'Pond', test_input)
 
     def test_reshape_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "reshape.pb"
-
-        input_shape = [1, 2, 3, 4]
-
-        path = export_reshape(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_reshape(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-            np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = np.ones([1, 2, 3, 4])
+        self._test_with_ndarray_input_fn('reshape', 'Pond', test_input)
 
     def test_expand_dims_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "expand_dims.pb"
-
-        input_shape = [2, 3, 4]
-
-        path = export_expand_dims(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_expand_dims(input_shape)
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = np.ones([2, 3, 4])
+        self._test_with_ndarray_input_fn('expand_dims', 'Pond', test_input)
 
     def test_pad_convert(self):
-        tf.reset_default_graph()
+        test_input = np.ones([2, 3])
+        self._test_with_ndarray_input_fn('pad', 'Pond', test_input)
 
-        global global_filename
-        global_filename = "pad.pb"
+    def test_batch_to_space_nd_convert(self):
+        test_input = np.ones([8, 1, 3, 1])
+        self._test_with_ndarray_input_fn('batch_to_space_nd', 'Pond', test_input)
 
-        input_shape = [2, 3]
-
-        path = export_pad(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_pad(input_shape)
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.array([[1, 2, 3], [4, 5, 6]]))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+    def test_space_to_batch_nd_convert(self):
+        test_input = np.ones([2, 2, 4, 1])
+        self._test_with_ndarray_input_fn('space_to_batch_nd', 'Pond', test_input)
 
     def test_squeeze_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "squeeze.pb"
-
-        input_shape = [1, 2, 3, 1]
-
-        path = export_squeeze(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_squeeze(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = np.ones([1, 2, 3, 1])
+        self._test_with_ndarray_input_fn('squeeze', 'Pond', test_input)
 
     def test_sub_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "sub.pb"
-
-        input_shape = [28, 1]
-
-        path = export_sub(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_sub(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = no.ones([28, 1])
+        self._test_with_ndarray_input_fn('sub', 'Pond', test_input)
 
     def test_mul_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "mul.pb"
-
-        input_shape = [4, 1]
-
-        path = export_mul(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_mul(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.array([1.0, 2.0, 3.0, 4.0]).reshape(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = np.array([[1., 2., 3., 4.]])
+        self._test_with_ndarray_input_fn('mul', 'Pond', test_input)
 
     def test_strided_slice_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "strided_slice.pb"
-
-        path = export_strided_slice(global_filename)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        input = [[[1, 1, 1], [2, 2, 2]],
-                 [[3, 3, 3], [4, 4, 4]],
-                 [[5, 5, 5], [6, 6, 6]]]
-
-        actual = run_strided_slice(input)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant([[[1, 1, 1], [2, 2, 2]],
-                                    [[3, 3, 3], [4, 4, 4]],
-                                    [[5, 5, 5], [6, 6, 6]]])
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        test_input = np.array([[[1, 1, 1], [2, 2, 2]],
+                               [[3, 3, 3], [4, 4, 4]],
+                               [[5, 5, 5], [6, 6, 6]]])
+        self._test_with_ndarray_input_fn('strided_slice', 'Pond', test_input)
 
     def test_batchnorm_convert(self):
-        tf.reset_default_graph()
+        test_input = np.ones([1, 1, 28, 28])
+        self._test_with_ndarray_input_fn('batchnorm', 'Pond', test_input)
 
-        global global_filename
-        global_filename = "batchnrom.pb"
+    def test_avgpool_convert(self):
+        test_input = np.ones([1, 28, 28, 1])
+        self._test_with_ndarray_input_fn('avgpooling', 'Pond', test_input)
 
-        input_shape = [1, 1, 28, 28]
-
-        path = export_batchnorm(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_batchnorm(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
-
-    def test_avgpooling_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "avgpool.pb"
-
-        input_shape = [1, 28, 28, 1]
-
-        path = export_avgpool(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_avgpool(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
-
-    def test_maxpooling_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "maxpool.pb"
-
-        input_shape = [1, 28, 28, 1]
-
-        path = export_maxpool(global_filename, input_shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_maxpool(input_shape)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.SecureNN() as prot:
-            prot.clear_initializers()
-
-            def provide_input():
-                return tf.constant(np.ones(input_shape))
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', provide_input)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+    def test_maxpool_convert(self):
+        test_input = np.ones([1, 28, 28, 1])
+        self._test_with_ndarray_input_fn('maxpool', 'SecureNN', test_input)
 
     def test_stack_convert(self):
-        tf.reset_default_graph()
-
-        global global_filename
-        global_filename = "stack.pb"
-
         input1 = np.array([1, 4])
         input2 = np.array([2, 5])
         input3 = np.array([3, 6])
+        graph_def, actual, prot_class = cls._construct_conversion_test('stack',
+                                                                       'Pond',
+                                                                       input1,
+                                                                       input2,
+                                                                       input3,
+                                                                       **kwargs)
 
-        path = export_stack(global_filename, input1.shape)
-
-        tf.reset_default_graph()
-
-        graph_def = read_graph(path)
-
-        tf.reset_default_graph()
-
-        actual = run_stack(input1, input2, input3)
-
-        tf.reset_default_graph()
-
-        with tfe.protocol.Pond() as prot:
-            prot.clear_initializers()
-
-            def provide_input1() -> tf.Tensor:
-                return tf.constant(input1)
-
-            def provide_input2() -> tf.Tensor:
-                return tf.constant(input2)
-
-            def provide_input3() -> tf.Tensor:
-                return tf.constant(input3)
-
-            inputs = [provide_input1, provide_input2, provide_input3]
-
-            converter = Converter(tfe.get_config(), prot, 'model-provider')
-
-            x = converter.convert(graph_def, register(), 'input-provider', inputs)
-
-            with tfe.Session() as sess:
-                sess.run(tf.global_variables_initializer())
-
-                output = sess.run(x.reveal(), tag='reveal')
-
-        np.testing.assert_array_almost_equal(output, actual, decimal=3)
+        with prot_class() as prot:
+            input_fns = [self.ndarray_input_fn(x) for x in test_inputs]
+            self._assert_successful_conversion(prot, graph_def, actual, *input_fns, **kwargs)
 
 
 def run_stack(input1, input2, input3):
@@ -657,18 +185,18 @@ def export_stack(filename: str, input_shape: Tuple[int]):
     return export(out, filename)
 
 
-def run_avgpool(input_shape: List[int]):
-    input = tf.placeholder(tf.float32, shape=input_shape, name="input")
+def run_avgpool(input):
+    input = tf.placeholder(tf.float32, shape=input.shape, name="input")
 
     x = tf.nn.avg_pool(input, [1, 2, 2, 1], [1, 2, 2, 1], 'VALID')
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={input: np.ones(input_shape)})
+        output = sess.run(x, feed_dict={input: input})
 
     return output
 
 
-def export_avgpool(filename: str, input_shape: List[int]):
+def export_avgpool(filename, input_shape):
     input = tf.placeholder(tf.float32, shape=input_shape, name="input")
 
     x = tf.nn.avg_pool(input, [1, 2, 2, 1], [1, 2, 2, 1], 'VALID')
@@ -676,18 +204,18 @@ def export_avgpool(filename: str, input_shape: List[int]):
     return export(x, filename)
 
 
-def run_maxpool(input_shape: List[int]):
-    input = tf.placeholder(tf.float32, shape=input_shape, name="input")
+def run_maxpool(input):
+    input = tf.placeholder(tf.float32, shape=input.shape, name="input")
 
     x = tf.nn.max_pool(input, [1, 2, 2, 1], [1, 2, 2, 1], 'VALID')
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={input: np.ones(input_shape)})
+        output = sess.run(x, feed_dict={input: input})
 
     return output
 
 
-def export_maxpool(filename: str, input_shape: List[int]):
+def export_maxpool(filename, input_shape):
     input = tf.placeholder(tf.float32, shape=input_shape, name="input")
 
     x = tf.nn.max_pool(input, [1, 2, 2, 1], [1, 2, 2, 1], 'VALID')
@@ -695,18 +223,19 @@ def export_maxpool(filename: str, input_shape: List[int]):
     return export(x, filename)
 
 
-def run_batchnorm(input_shape: List[int]):
-    input = tf.placeholder(tf.float32, shape=input_shape, name="input")
+def run_batchnorm(input):
+    x = tf.placeholder(tf.float32, shape=input.shape, name="input")
 
-    mean = np.ones((1, 1, 1, input_shape[3])) * 1
-    variance = np.ones((1, 1, 1, input_shape[3])) * 2
-    offset = np.ones((1, 1, 1, input_shape[3])) * 3
-    scale = np.ones((1, 1, 1, input_shape[3])) * 4
+    dim = input.shape[3]
+    mean = np.ones((1, 1, 1, dim)) * 1
+    variance = np.ones((1, 1, 1, dim)) * 2
+    offset = np.ones((1, 1, 1, dim)) * 3
+    scale = np.ones((1, 1, 1, dim)) * 4
 
-    x = tf.nn.batch_normalization(input, mean, variance, offset, scale, 0.00001)
+    y = tf.nn.batch_normalization(x, mean, variance, offset, scale, 0.00001)
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={input: np.ones(input_shape)})
+        output = sess.run(y, feed_dict={x: input})
 
     return output
 
@@ -724,18 +253,18 @@ def export_batchnorm(filename: str, input_shape: List[int]):
     return export(x, filename)
 
 
-def run_cnn(input_shape: List[int], data_format="NCHW"):
-    input = tf.placeholder(tf.float32, shape=input_shape, name="input")
+def run_cnn(input, data_format="NCHW"):
+    feed_me = tf.placeholder(tf.float32, shape=input.shape, name="input")
 
-    x = input
+    x = ph
     if data_format == "NCHW":
-        x = tf.transpose(input, (0, 2, 3, 1))
+        x = tf.transpose(ph, (0, 2, 3, 1))
 
     filter = tf.constant(np.ones((5, 5, 1, 16)), dtype=tf.float32, name="weights")
     x = tf.nn.conv2d(x, filter, (1, 1, 1, 1), "SAME", name="conv2d")
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={input: np.ones(input_shape)})
+        output = sess.run(x, feed_dict={feed_me: input})
 
         if data_format == "NCHW":
             output = output.transpose(0, 3, 1, 2)
@@ -752,14 +281,14 @@ def export_cnn(filename: str, input_shape: List[int], data_format="NCHW"):
     return export(x, filename)
 
 
-def run_matmul(input_shape: List[int]):
-    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
-    b = tf.constant(np.ones((input_shape[1], 1)), dtype=tf.float32)
+def run_matmul(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
+    b = tf.constant(np.ones((input.shape[1], 1)), dtype=tf.float32)
 
     x = tf.matmul(a, b)
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={a: np.ones(input_shape)})
+        output = sess.run(x, feed_dict={a: input})
 
     return output
 
@@ -773,14 +302,14 @@ def export_matmul(filename: str, input_shape: List[int]):
     return export(x, filename)
 
 
-def run_add(input_shape: List[int]):
-    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
-    b = tf.constant(np.ones((input_shape[1], 1)), dtype=tf.float32)
+def run_add(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
+    b = tf.constant(np.ones((input.shape[1], 1)), dtype=tf.float32)
 
     x = tf.add(a, b)
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={a: np.ones(input_shape)})
+        output = sess.run(x, feed_dict={a: input})
 
     return output
 
@@ -794,13 +323,13 @@ def export_add(filename: str, input_shape: List[int]):
     return export(x, filename)
 
 
-def run_transpose(input_shape: List[int]):
-    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
+def run_transpose(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
 
     x = tf.transpose(a, perm=(0, 3, 1, 2))
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={a: np.ones(input_shape)})
+        output = sess.run(x, feed_dict={a: input})
 
     return output
 
@@ -813,17 +342,17 @@ def export_transpose(filename: str, input_shape: List[int]):
     return export(x, filename)
 
 
-def run_reshape(input_shape: List[int]):
-    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
+def run_reshape(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
 
     last_size = 1
-    for i in input_shape[1:]:
+    for i in input.shape[1:]:
         last_size *= i
 
     x = tf.reshape(a, [-1, last_size])
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={a: np.ones(input_shape)})
+        output = sess.run(x, feed_dict={a: input})
 
     return output
 
@@ -840,13 +369,13 @@ def export_reshape(filename: str, input_shape: List[int]):
     return export(x, filename)
 
 
-def run_expand_dims(input_shape: List[int]):
-    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
+def run_expand_dims(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
 
     x = tf.expand_dims(a, axis=0)
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={a: np.ones(input_shape)})
+        output = sess.run(x, feed_dict={a: input})
 
     return output
 
@@ -859,6 +388,17 @@ def export_expand_dims(filename: str, input_shape: List[int]):
     return export(x, filename)
 
 
+def run_pad(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
+
+    x = tf.pad(a, paddings=tf.constant([[2, 2], [3, 4]]), mode="CONSTANT")
+
+    with tf.Session() as sess:
+        output = sess.run(x, feed_dict={a: input})
+
+    return output
+
+
 def export_pad(filename: str, input_shape: List[int]):
     a = tf.placeholder(tf.float32, shape=input_shape, name="input")
 
@@ -867,59 +407,94 @@ def export_pad(filename: str, input_shape: List[int]):
     return export(x, filename)
 
 
-def run_squeeze(input_shape: List[int]):
+def _construct_batch_to_space_nd(input_shape):
     a = tf.placeholder(tf.float32, shape=input_shape, name="input")
+    block_shape = tf.constant([2, 2], dtype=tf.int32)
+    crops = tf.constant([[0, 0], [2, 0]], dtype=tf.int32)
+    x = tf.batch_to_space_nd(a, block_shape=block_shape, crops=crops)
+    return x
 
+
+def export_batch_to_space_nd(filename, input_shape):
+    x = _core_batch_to_space_nd_construct(input_shape)
+    return export(x, filename)
+
+
+def run_batch_to_space_nd(input):
+    x = _core_batch_to_space_nd_construct(input.shape)
+    with tf.Session() as sess:
+        output = sess.run(x, feed_dict={a: input})
+    return output
+
+
+def _construct_space_to_batch_nd(input_shape):
+    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
+    block_shape = tf.constant([2, 2], dtype=tf.int32)
+    crops = tf.constant([[0, 0], [2, 0]], dtype=tf.int32)
+    x = tf.space_to_batch_nd(a, block_shape=block_shape, crops=crops)
+    return x
+
+
+def export_space_to_batch_nd(filename, input_shape):
+    x = _core_space_to_batch_nd_construct(input_shape)
+    return export(x, filename)
+
+
+def run_space_to_batch_nd(input):
+    x = _core_space_to_batch_nd_construct(input.shape)
+    with tf.Session() as sess:
+        output = sess.run(x, feed_dict={a: input})
+    return output
+
+
+def run_squeeze(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
     x = tf.squeeze(a, axis=[0, 3])
+    with tf.Session() as sess:
+        output = sess.run(x, feed_dict={a: input})
+    return output
+
+
+def export_squeeze(filename, input_shape):
+    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
+    x = tf.squeeze(a, axis=[0, 3])
+    return export(x, filename)
+
+
+def run_sub(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
+    b = tf.constant(np.ones((input.shape[0], 1)), dtype=tf.float32)
+
+    x = tf.subtract(a, b)
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={a: np.ones(input_shape)})
+        output = sess.run(x, feed_dict={a: input})
 
     return output
 
 
-def export_squeeze(filename: str, input_shape: List[int]):
-    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
-
-    x = tf.squeeze(a, axis=[0, 3])
-
-    return export(x, filename)
-
-
-def run_sub(input_shape: List[int]):
+def export_sub(filename, input_shape):
     a = tf.placeholder(tf.float32, shape=input_shape, name="input")
     b = tf.constant(np.ones((input_shape[0], 1)), dtype=tf.float32)
 
     x = tf.subtract(a, b)
 
-    with tf.Session() as sess:
-        output = sess.run(x, feed_dict={a: np.ones(input_shape)})
-
-    return output
-
-
-def export_sub(filename: str, input_shape: List[int]):
-    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
-    b = tf.constant(np.ones((input_shape[0], 1)), dtype=tf.float32)
-
-    x = tf.subtract(a, b)
-
     return export(x, filename)
 
 
-def run_mul(input_shape: List[int]):
-    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
-    b = tf.constant(np.array([1.0, 2.0, 3.0, 4.0]).reshape(input_shape), dtype=tf.float32)
+def run_mul(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
+    b = tf.constant(np.array([1.0, 2.0, 3.0, 4.0]).reshape(input.shape), dtype=tf.float32)
 
     x = tf.multiply(a, b)
 
     with tf.Session() as sess:
-        output = sess.run(x, feed_dict={a: np.array([1.0, 2.0, 3.0, 4.0]).reshape(input_shape)})
+        output = sess.run(x, feed_dict={a: input})
 
     return output
 
 
-def export_mul(filename: str, input_shape: List[int]):
+def export_mul(filename, input_shape):
     a = tf.placeholder(tf.float32, shape=input_shape, name="input")
     b = tf.constant(np.array([1.0, 2.0, 3.0, 4.0]).reshape(input_shape), dtype=tf.float32)
 
@@ -936,11 +511,11 @@ def export_strided_slice(filename: str, input_shape: List[int] = [3, 2, 3]):
 
 
 def run_strided_slice(input):
-    t = tf.constant(input, dtype=tf.float32)
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
     out = tf.strided_slice(t, [1, 0, 0], [2, 1, 3], [1, 1, 1])
 
     with tf.Session() as sess:
-        output = sess.run(out)
+        output = sess.run(out).feed_dict({a: input})
 
     return output
 

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -1,7 +1,5 @@
 import unittest
 
-from typing import List
-
 import numpy as np
 import tensorflow as tf
 import tf_encrypted as tfe

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -6,6 +6,8 @@ import numpy as np
 import tensorflow as tf
 import tf_encrypted as tfe
 
+from .test_convert import run_pad
+
 
 class TestPad(unittest.TestCase):
     def setUp(self):
@@ -30,20 +32,9 @@ class TestPad(unittest.TestCase):
 
             tf.reset_default_graph()
 
-            out_tensorflow = run_pad([2, 3])
+            out_tensorflow = run_pad(input)
 
             np.testing.assert_allclose(out_tfe, out_tensorflow, atol=.01)
-
-
-def run_pad(input_shape: List[int]):
-    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
-
-    x = tf.pad(a, paddings=tf.constant([[2, 2], [3, 4]]), mode="CONSTANT")
-
-    with tf.Session() as sess:
-        output = sess.run(x, feed_dict={a: np.array([[1, 2, 3], [4, 5, 6]])})
-
-    return output
 
 
 if __name__ == '__main__':

--- a/tf_encrypted/convert/register.py
+++ b/tf_encrypted/convert/register.py
@@ -32,9 +32,10 @@ def register() -> Dict[str, Any]:
         'Squeeze': squeeze,
         'ConcatV2': concat,
         'BiasAdd': bias_add,
-        # 'Pack': pack,
         'MaxPool': maxpool,
         'Pad': pad,
+        'BatchToSpaceND': batch_to_space_nd,
+        'SpaceToBatchND': space_to_batch_nd,
     }
 
     return reg
@@ -366,6 +367,22 @@ def concat(converter: Converter, node: Any, inputs: List[str]) -> Any:
     axis = converter.outputs[inputs[2]]
 
     return converter.protocol.concat([input0, input1], axis.attr["value"].tensor.int_val[0])
+
+
+def batch_to_space_nd(converter, node, inputs):
+    input = converter.outputs[inputs[0]]
+    block_shape = converter.outputs[inputs[1]].attr["value"].tensor
+    crops = converter.outputs[inputs[2]].attr["value"].tensor
+
+    return converter.protocol.batch_to_space_nd(input, block_shape, crops)
+
+
+def space_to_batch_nd(converter, node, inputs):
+    input = converter.outputs[inputs[0]]
+    block_shape = converter.outputs[inputs[1]].attr["value"].tensor
+    paddings = converter.outputs[inputs[2]].attr["value"].tensor
+
+    return converter.protocol.space_to_batch_nd(input, block_shape, paddings)
 
 
 def nodef_to_public_pond(converter: Converter, x: Any) -> PondPublicTensor:


### PR DESCRIPTION
Noticed `test_convert.py` had tons of repeated code, so wanted to clean it up.

Tests are now auto-generated for each op, assuming you've written well-defined `run_<op>` and `export_<op>` functions.