### PR TITLE
only support tensorflow 1.12

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,6 +62,8 @@ $ git clone https://github.com/mortendahl/tf-encrypted.git
 
 Once the clone is complete, you can switch into the tf-encrypted library using `cd tf-encrypted` and then install the dependencies using `make bootstrap` which will error if any dependencies are missing.
 
+Note: tf-encrypted currently only supports running alongside tensorflow 1.12.0+.
+
 ```
 $ cd tf-encrypted
 $ make bootstrap

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: test
 # ###############################################
 DOCKER_REQUIRED_VERSION=18.
 PYTHON_REQUIRED_VERSION=3.5.
-TENSORFLOW_REQUIRED_VERSION=1.9
+TENSORFLOW_REQUIRED_VERSION=1.12
 SHELL := /bin/bash
 
 CURRENT_DIR=$(shell pwd)
@@ -140,7 +140,7 @@ endif
 DOCKER_BUILD=docker build -t mortendahl/tf-encrypted:$(1) -f Dockerfile $(2) .
 docker: Dockerfile dockercheck
 	$(call DOCKER_BUILD,latest,)
-	$(call DOCKER_BUILD,latest-int64,--build-arg TF_WHL_URL=https://storage.googleapis.com/dropoutlabs-tensorflow-builds/tensorflow-1.9.0-cp35-cp35m-linux_x86_64.whl)
+	$(call DOCKER_BUILD,latest-int64,--build-arg TF_WHL_URL=https://storage.googleapis.com/dropoutlabs-tensorflow-builds/tensorflow-1.12.0-cp35-cp35m-linux_x86_64.whl)
 
 .PHONY: docker
 
@@ -307,12 +307,6 @@ $(SECURE_OUT_PRE)$(CURRENT_TF_VERSION).so: $(LIBSODIUM_OUT) $(SECURE_IN) $(SECUR
 build: $(SECURE_OUT_PRE)$(CURRENT_TF_VERSION).so
 
 build-all:
-	pip install tensorflow==1.9.0
-	$(MAKE) $(SECURE_OUT_PRE)1.9.0.so
-	pip install tensorflow==1.10.0
-	$(MAKE) $(SECURE_OUT_PRE)1.10.0.so
-	pip install tensorflow==1.11.0
-	$(MAKE) $(SECURE_OUT_PRE)1.11.0.so
 	pip install tensorflow==1.12.0
 	$(MAKE) $(SECURE_OUT_PRE)1.12.0.so
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The project has benefitted enormously from the efforts of several contributors f
 
 # Installation & Usage
 
-tf-encrypted is available as a package on [PyPI](https://pypi.org/project/tf-encrypted/) supporting Python 3.5+ which can be installed using pip:
+tf-encrypted is available as a package on [PyPI](https://pypi.org/project/tf-encrypted/) supporting Python 3.5+ and tensorflow 1.12.0+ which can be installed using pip:
 
 ```bash
 $ pip install tf-encrypted

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -1,11 +1,11 @@
 Installation
 =============
 
-tf-encrypted is available as a package on `PyPA`_ and supports Python 3.5+. You can install the package using pip::
+tf-encrypted is available as a package on `PyPA`_ and supports Python 3.5+ and tensorflow 1.12.0+. You can install the package using pip::
 
    pip install tf-encrypted
 
-A `change log`_ is kept for each version of tf-encrypted released which can be found on `GitHub`_. 
+A `change log`_ is kept for each version of tf-encrypted released which can be found on `GitHub`_.
 
 Once installed, you can import the package into your code as shown below::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ requests==2.20.0
 s3transfer==0.1.13
 six==1.11.0
 tensorboard==1.9.0
-tensorflow==1.12.0
+tensorflow>=1.12.0
 termcolor==1.1.0
 typed-ast==1.1.0
 urllib3==1.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ pycparser==2.18
 requests==2.20.0
 s3transfer==0.1.13
 six==1.11.0
-tensorboard==1.9.0
 tensorflow>=1.12.0
 termcolor==1.1.0
 typed-ast==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ requests==2.20.0
 s3transfer==0.1.13
 six==1.11.0
 tensorboard==1.9.0
-tensorflow>=1.9.0
+tensorflow==1.12.0
 termcolor==1.1.0
 typed-ast==1.1.0
 urllib3==1.23

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ setuptools.setup(
     ]},
     python_requires=">=3.5",
     install_requires=[
-        "tensorflow==1.12.0",
+        "tensorflow>=1.12.0",
         "numpy>=1.14.0"
     ],
     extra_requires={
-        "tf": ["tensorflow==1.12.0"]
+        "tf": ["tensorflow>=1.12.0"]
     },
     license="Apache License 2.0",
     url="https://github.com/mortendahl/tf-encrypted",

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ setuptools.setup(
     ]},
     python_requires=">=3.5",
     install_requires=[
-        "tensorflow>=1.9.0",
+        "tensorflow==1.12.0",
         "numpy>=1.14.0"
     ],
     extra_requires={
-        "tf": ["tensorflow>=1.9.0"]
+        "tf": ["tensorflow==1.12.0"]
     },
     license="Apache License 2.0",
     url="https://github.com/mortendahl/tf-encrypted",


### PR DESCRIPTION
Closes https://github.com/mortendahl/tf-encrypted/issues/345

This removes the implicit support we had for other versions of tensorflow. Only support 1.12 now!