### PR TITLE
Tests and optimizations related to #339

### DIFF
--- a/examples/gdamaskinos.py
+++ b/examples/gdamaskinos.py
@@ -14,7 +14,7 @@ print("Support for int64: ", tfe.config.tensorflow_supports_int64())
 tf.set_random_seed(42)
 np.random.seed(42)
 
-small = True
+small = False
 if small:
   print("Running CNN with small input")
 else:

--- a/examples/gdamaskinos.py
+++ b/examples/gdamaskinos.py
@@ -14,7 +14,7 @@ print("Support for int64: ", tfe.config.tensorflow_supports_int64())
 tf.set_random_seed(42)
 np.random.seed(42)
 
-small = False
+small = True
 if small:
   print("Running CNN with small input")
 else:

--- a/examples/gdamaskinos.py
+++ b/examples/gdamaskinos.py
@@ -1,0 +1,173 @@
+import sys
+import time
+import numpy as np
+
+from functools import partial
+from functools import reduce
+import tensorflow as tf
+import tf_encrypted as tfe
+from tensorflow.python.framework import graph_util, graph_io
+
+print(tfe.__file__)
+print("Support for int64: ", tfe.config.tensorflow_supports_int64())
+
+tf.set_random_seed(42)
+np.random.seed(42)
+
+small = True
+if small:
+  print("Running CNN with small input")
+else:
+  print("Running CNN with large input")
+
+config = tfe.LocalConfig([
+    'server0',
+    'server1',
+    'crypto-producer',
+    'weights-provider',
+    'prediction-client'
+])
+
+#config = tfe.RemoteConfig([
+#  ('server0', 'server0:4441'),
+#  ('server1', 'server1:4442'),
+#  ('crypto-producer', 'server2: 4443'),
+#  ('weights-provider', 'server3: 4444'),
+#  ('prediction-client', 'server2:4442')
+#  ], log_device_placement=False)
+
+if len(sys.argv) > 1:
+  if isinstance(config, tfe.LocalConfig):
+      raise Exception("You can launch a configured server only with a remote configuration")
+  player_name = str(sys.argv[1])
+  server = config.server(player_name)
+  server.start()
+  server.join()
+
+tfe.set_config(config)
+tfe.set_protocol(tfe.protocol.SecureNN())
+
+input_shape1 = [1, 3, 32, 32]
+input_shape2 = [1, 3, 192, 192]
+conv1_fshape = [3, 3, 3, 32]
+
+def provide_input_conv1weights() -> tf.Tensor:
+  w = tf.constant(np.random.normal(size=conv1_fshape), dtype=tf.float32)
+  return w
+
+def provide_input_denseweights(shape) -> tf.Tensor:
+  w = tf.constant(np.random.normal(size=[shape, 2]), dtype=tf.float32)
+  return w
+
+def provide_input_prediction() -> tf.Tensor:
+  x = tf.random_normal(shape=input_shape1, dtype=tf.float32, seed=42)
+  return x
+
+def provide_input_prediction2() -> tf.Tensor:
+  x = tf.random_normal(shape=input_shape2, dtype=tf.float32)
+  return x
+
+def receive_output(tensor: tf.Tensor) -> tf.Operation:
+  return tf.Print(tensor, [tensor, tf.shape(tensor)], message="output:")
+
+def tfe_inference(x):
+  conv1 = tfe.layers.Conv2D(x.shape.as_list(), conv1_fshape, 1, "SAME")
+  initial_w_conv1 = tfe.define_private_input('weights-provider',
+                                             provide_input_conv1weights)
+  conv1.initialize(initial_w_conv1)
+  x = conv1.forward(x)
+  relu1 = tfe.layers.activation.Relu(x.shape.as_list())
+  x = relu1.forward(x)
+  pool1 = tfe.layers.pooling.MaxPooling2D(x.shape.as_list(), pool_size=2,
+                                          strides=2, padding='SAME')
+
+  x = pool1.forward(x)
+  shape = reduce(lambda x,y: x*y, x.shape.as_list())
+  x = x.reshape([-1, shape])
+
+  part = partial(provide_input_denseweights, shape)
+  initial_w_dense = tfe.define_private_input('weights-provider', part)
+  x = tfe.matmul(x, initial_w_dense)
+  return x
+
+def tf_inference(x, data_format="NHWC"):
+  """Tensorflow only supports inference with NHWC; tfe convert needs NCHW"""
+  x = tf.nn.conv2d(x, provide_input_conv1weights(), strides=[1,1,1,1],
+                   padding="SAME", data_format=data_format)
+  x = tf.nn.relu(x)
+  x = tf.nn.max_pool(x, ksize=[1,2,2,1], strides=[1,2,2,1], padding='SAME',
+                     data_format=data_format)
+
+  shape = reduce(lambda x,y: x*y, x.shape.as_list())
+  x = tf.reshape(x, shape=[-1, shape])
+  return tf.matmul(x, provide_input_denseweights(shape))
+
+def export_cnn(x):
+  x = tf_inference(x, data_format='NCHW')
+
+  pred_node_names = ["output"]
+  tf.identity(x, name=pred_node_names[0])
+
+  with tf.Session() as sess:
+    constant_graph = graph_util.convert_variables_to_constants(sess,
+                                                               sess.graph.as_graph_def(),
+                                                               pred_node_names)
+  frozen = graph_util.remove_training_nodes(constant_graph)
+  graph_io.write_graph(frozen, ".", "bench_cnn.pb", as_text=False)
+
+if small:
+  input_func = provide_input_prediction
+else:
+  input_func = provide_input_prediction2
+
+with tf.Graph().as_default():
+  print("Exporting graph...")
+  x = input_func()
+  x = tf.placeholder(tf.float32, shape=x.shape)
+  export_cnn(x)
+
+with tf.Graph().as_default():
+  print("Loading graph...")
+  with tf.gfile.GFile("bench_cnn.pb", 'rb') as f:
+    graph_def = tf.GraphDef()
+    graph_def.ParseFromString(f.read())
+
+with tf.Graph().as_default():
+  print("TFE")
+  c = tfe.convert.Converter(config, tfe.get_protocol(),
+                            config.get_player('weights-provider'))
+  y = c.convert(graph_def, tfe.convert.register(),
+                config.get_player('prediction-client'), input_func)
+
+  #x = tfe.define_private_input('prediction-client', input_func)
+  #y = tfe_inference(x)
+
+  prediction_op = tfe.define_output('prediction-client', [y], receive_output)
+
+  with tfe.Session(config=config) as sess:
+      print("Initialize tensors")
+      sess.run(tf.global_variables_initializer(), tag='init')
+
+      print("Predict")
+      for i in range(3):
+        t = time.time()
+        sess.run(prediction_op, tag='prediction')
+        print("Inference time: %g" % (time.time() - t))
+
+
+with tf.Graph().as_default():
+  print("TF")
+  x = input_func()
+  x = tf.transpose(x, (0,2,3,1)) # NHWC
+
+  prediction_op = tf_inference(x)
+
+  with tf.Session() as sess:
+      print("Initialize tensors")
+      sess.run(tf.global_variables_initializer())
+
+      print("Predict")
+      for i in range(3):
+        t = time.time()
+        sess.run(prediction_op)
+        print("Inference time: %g" % (time.time() - t))

--- a/tf_encrypted/convert/register.py
+++ b/tf_encrypted/convert/register.py
@@ -395,7 +395,7 @@ def required_space_to_batch_paddings(converter: Converter, node: Any, inputs: Li
             inputs_int32.append(nodef_to_numpy_array(inputs_node[i]))
         else:
             msg = "Revealing private input: required_space_to_batch_paddings assumes public input."
-            logging.warn(msg)
+            logging.warning(msg)
             inputs_int32.append(tf.cast(inputs_node[i].reveal().decode(), tf.int32))
 
     if len(inputs_int32) == 2:

--- a/tf_encrypted/protocol/pond.py
+++ b/tf_encrypted/protocol/pond.py
@@ -2441,21 +2441,24 @@ def _mul_masked_masked(prot, x, y):
     a, a0, a1, alpha_on_0, alpha_on_1 = x.unwrapped
     b, b0, b1, beta_on_0, beta_on_1 = y.unwrapped
 
-    with tf.name_scope("mul"):
+    with tf.name_scope('mul'):
 
         with tf.device(prot.crypto_producer.device_name):
-            ab = a * b
-            ab0, ab1 = prot._share(ab)
+            with tf.name_scope('triple'):
+                ab = a * b
+                ab0, ab1 = prot._share(ab)
 
         with tf.device(prot.server_0.device_name):
-            alpha = alpha_on_0
-            beta = beta_on_0
-            z0 = ab0 + (a0 * beta) + (alpha * b0) + (alpha * beta)
+            with tf.name_scope('combine'):
+                alpha = alpha_on_0
+                beta = beta_on_0
+                z0 = ab0 + (a0 * beta) + (alpha * b0) + (alpha * beta)
 
         with tf.device(prot.server_1.device_name):
-            alpha = alpha_on_1
-            beta = beta_on_1
-            z1 = ab1 + (a1 * beta) + (alpha * b1)
+            with tf.name_scope('combine'):
+                alpha = alpha_on_1
+                beta = beta_on_1
+                z1 = ab1 + (a1 * beta) + (alpha * b1)
 
         z = PondPrivateTensor(prot, z0, z1, x.is_scaled or y.is_scaled)
         z = prot.truncate(z) if x.is_scaled and y.is_scaled else z
@@ -2616,21 +2619,24 @@ def _matmul_masked_masked(prot, x, y):
     a, a0, a1, alpha_on_0, alpha_on_1 = x.unwrapped
     b, b0, b1, beta_on_0, beta_on_1 = y.unwrapped
 
-    with tf.name_scope("matmul"):
+    with tf.name_scope('matmul'):
 
         with tf.device(prot.crypto_producer.device_name):
-            ab = a.matmul(b)
-            ab0, ab1 = prot._share(ab)
+            with tf.name_scope('triple'):
+                ab = a.matmul(b)
+                ab0, ab1 = prot._share(ab)
 
         with tf.device(prot.server_0.device_name):
-            alpha = alpha_on_0
-            beta = beta_on_0
-            z0 = ab0 + a0.matmul(beta) + alpha.matmul(b0) + alpha.matmul(beta)
+            with tf.name_scope('combine'):
+                alpha = alpha_on_0
+                beta = beta_on_0
+                z0 = ab0 + a0.matmul(beta) + alpha.matmul(b0) + alpha.matmul(beta)
 
         with tf.device(prot.server_1.device_name):
-            alpha = alpha_on_1
-            beta = beta_on_1
-            z1 = ab1 + a1.matmul(beta) + alpha.matmul(b1)
+            with tf.name_scope('combine'):
+                alpha = alpha_on_1
+                beta = beta_on_1
+                z1 = ab1 + a1.matmul(beta) + alpha.matmul(b1)
 
         z = PondPrivateTensor(prot, z0, z1, x.is_scaled or y.is_scaled)
         z = prot.truncate(z) if x.is_scaled and y.is_scaled else z
@@ -2704,30 +2710,33 @@ def _conv2d_masked_masked(prot, x, y, strides, padding):
     a, a0, a1, alpha_on_0, alpha_on_1 = x.unwrapped
     b, b0, b1, beta_on_0, beta_on_1 = y.unwrapped
 
-    with tf.name_scope("conv2d"):
+    with tf.name_scope('conv2d'):
 
         with tf.device(prot.crypto_producer.device_name):
-            a_conv2d_b = a.conv2d(b, strides, padding)
-            a_conv2d_b0, a_conv2d_b1 = prot._share(a_conv2d_b)
+            with tf.name_scope('triple'):
+                a_conv2d_b = a.conv2d(b, strides, padding)
+                a_conv2d_b0, a_conv2d_b1 = prot._share(a_conv2d_b)
 
         with tf.device(prot.server_0.device_name):
-            alpha = alpha_on_0
-            beta = beta_on_0
-            z0 = (
-                a_conv2d_b0
-                + a0.conv2d(beta, strides, padding)
-                + alpha.conv2d(b0, strides, padding)
-                + alpha.conv2d(beta, strides, padding)
-            )
+            with tf.name_scope('combine'):
+                alpha = alpha_on_0
+                beta = beta_on_0
+                z0 = (
+                    a_conv2d_b0
+                    + a0.conv2d(beta, strides, padding)
+                    + alpha.conv2d(b0, strides, padding)
+                    + alpha.conv2d(beta, strides, padding)
+                )
 
         with tf.device(prot.server_1.device_name):
-            alpha = alpha_on_1
-            beta = beta_on_1
-            z1 = (
-                a_conv2d_b1
-                + a1.conv2d(beta, strides, padding)
-                + alpha.conv2d(b1, strides, padding)
-            )
+            with tf.name_scope('combine'):
+                alpha = alpha_on_1
+                beta = beta_on_1
+                z1 = (
+                    a_conv2d_b1
+                    + a1.conv2d(beta, strides, padding)
+                    + alpha.conv2d(b1, strides, padding)
+                )
 
         z = PondPrivateTensor(prot, z0, z1, x.is_scaled or y.is_scaled)
         z = prot.truncate(z) if x.is_scaled and y.is_scaled else z

--- a/tf_encrypted/protocol/securenn/securenn.py
+++ b/tf_encrypted/protocol/securenn/securenn.py
@@ -550,7 +550,8 @@ def _lsb_private(prot, x: PondPrivateTensor):
                 beta = PondPublicTensor(prot, beta_raw, beta_raw, is_scaled=False)
 
         with tf.name_scope('lsb_compare'):
-            c = prot.cast_backing((x + r).reveal(), out_dtype)
+            c = (x + r).reveal()
+            c = prot.cast_backing(c, out_dtype)
             c.is_scaled = False
 
             greater_xor_beta = _private_compare(prot, rbits, c, beta)

--- a/tf_encrypted/tensor/__init__.py
+++ b/tf_encrypted/tensor/__init__.py
@@ -24,13 +24,7 @@ from .int32 import (
     Int32Constant,
 )
 
-from .int64 import (
-    int64factory,
-    Int64Tensor,
-    Int64Placeholder,
-    Int64Variable,
-    Int64Constant,
-)
+from .int64 import int64factory
 
 from .fixed import (
     _validate_fixedpoint_config,

--- a/tf_encrypted/tensor/__init__.py
+++ b/tf_encrypted/tensor/__init__.py
@@ -54,8 +54,4 @@ __all__ = [
     'Int32Placeholder',
     'Int32Variable',
     'Int32Constant',
-    'Int64Tensor',
-    'Int64Placeholder',
-    'Int64Variable',
-    'Int64Constant',
 ]

--- a/tf_encrypted/tensor/factory.py
+++ b/tf_encrypted/tensor/factory.py
@@ -1,19 +1,17 @@
 import abc
-from typing import List, Tuple, Union, TypeVar, Generic
-
-import tensorflow as tf
+from typing import List, TypeVar, Generic, Optional
 
 
 class AbstractTensor(abc.ABC):
 
     @property
-    @abc.abstractmethod
+    @abc.abstractproperty
     def factory(self) -> 'AbstractFactory':
         pass
 
     @property
-    @abc.abstractmethod
-    def shape(self) -> Union[Tuple[int, ...], tf.TensorShape]:
+    @abc.abstractproperty
+    def shape(self):
         pass
 
 
@@ -50,11 +48,15 @@ class AbstractFactory(abc.ABC, Generic[T, C, V, P]):
         pass
 
     @abc.abstractmethod
-    def placeholder(self, shape: List[int]) -> P:
+    def placeholder(self, shape) -> P:
         pass
 
     @abc.abstractmethod
-    def sample_uniform(self, shape: List[int], seed=None) -> T:
+    def sample_uniform(self, shape, minval: Optional[int] = None) -> T:
+        pass
+
+    @abc.abstractmethod
+    def sample_bounded(self, shape, bitlength: int) -> T:
         pass
 
     @abc.abstractmethod

--- a/tf_encrypted/tensor/factory.py
+++ b/tf_encrypted/tensor/factory.py
@@ -35,6 +35,16 @@ P = TypeVar('P')
 
 class AbstractFactory(abc.ABC, Generic[T, C, V, P]):
 
+    @property
+    @abc.abstractproperty
+    def modulus(self) -> int:
+        pass
+
+    @property
+    @abc.abstractproperty
+    def native_type(self):
+        pass
+
     @abc.abstractmethod
     def tensor(self, value) -> T:
         pass
@@ -65,9 +75,4 @@ class AbstractFactory(abc.ABC, Generic[T, C, V, P]):
 
     @abc.abstractmethod
     def concat(self, xs: List[T], axis: int) -> T:
-        pass
-
-    @property
-    @abc.abstractmethod
-    def modulus(self) -> int:
         pass

--- a/tf_encrypted/tensor/int32.py
+++ b/tf_encrypted/tensor/int32.py
@@ -72,6 +72,11 @@ class Int32Factory(AbstractFactory):
 
         return Int32Tensor(value)
 
+    def sample_bounded(self,
+                       shape,
+                       bitlength: int) -> 'Int64Tensor':
+        raise NotImplementedError()
+
     def stack(self, xs: List['Int32Tensor'], axis: int = 0) -> 'Int32Tensor':
         assert all(isinstance(x, Int32Tensor) for x in xs)
         value = tf.stack([x.value for x in xs], axis=axis)

--- a/tf_encrypted/tensor/int64.py
+++ b/tf_encrypted/tensor/int64.py
@@ -236,7 +236,7 @@ class Int64Tensor(AbstractTensor):
 
     def cast(self, factory):
         assert factory.native_type == self.factory.native_type
-        return Int64DenseTensor(self.value)
+        return factory.tensor(self.value)
 
 
 class Int64DenseTensor(Int64Tensor):

--- a/tf_encrypted/tensor/prime.py
+++ b/tf_encrypted/tensor/prime.py
@@ -193,11 +193,15 @@ class PrimeFactory(AbstractFactory):
 
     def __init__(self, modulus, native_type=tf.int32):
         self._modulus = modulus
-        self.native_type = native_type
+        self._native_type = native_type
 
     @property
     def modulus(self):
         return self._modulus
+
+    @property
+    def native_type(self):
+        return self._native_type
 
     def sample_uniform(self, shape, minval: Optional[int] = 0) -> PrimeTensor:
         value = random_uniform(shape=shape,

--- a/tf_encrypted/tensor/shared.py
+++ b/tf_encrypted/tensor/shared.py
@@ -67,22 +67,24 @@ def conv2d(
     padding: str
 ) -> AbstractTensor:
 
-    h_filter, w_filter, d_filters, n_filters = map(int, y.shape)
-    n_x, d_x, h_x, w_x = map(int, x.shape)
-    if padding == 'SAME':
-        h_out = int(math.ceil(float(h_x) / float(strides)))
-        w_out = int(math.ceil(float(w_x) / float(strides)))
-    elif padding == 'VALID':
-        h_out = int(math.ceil(float(h_x - h_filter + 1) / float(strides)))
-        w_out = int(math.ceil(float(w_x - w_filter + 1) / float(strides)))
-    else:
-        raise ValueError("Don't know padding method '{}'".format(padding))
+    with tf.name_scope('conv2d'):
 
-    X_col = x.im2col(h_filter, w_filter, padding, strides)
-    W_col = y.transpose([3, 2, 0, 1]).reshape([int(n_filters), -1])
-    out = W_col.matmul(X_col)
+        h_filter, w_filter, d_filters, n_filters = map(int, y.shape)
+        n_x, d_x, h_x, w_x = map(int, x.shape)
+        if padding == 'SAME':
+            h_out = int(math.ceil(float(h_x) / float(strides)))
+            w_out = int(math.ceil(float(w_x) / float(strides)))
+        elif padding == 'VALID':
+            h_out = int(math.ceil(float(h_x - h_filter + 1) / float(strides)))
+            w_out = int(math.ceil(float(w_x - w_filter + 1) / float(strides)))
+        else:
+            raise ValueError("Don't know padding method '{}'".format(padding))
 
-    out = out.reshape([n_filters, h_out, w_out, n_x])
-    out = out.transpose([3, 0, 1, 2])
+        X_col = x.im2col(h_filter, w_filter, padding, strides)
+        W_col = y.transpose([3, 2, 0, 1]).reshape([int(n_filters), -1])
+        out = W_col.matmul(X_col)
 
-    return out
+        out = out.reshape([n_filters, h_out, w_out, n_x])
+        out = out.transpose([3, 0, 1, 2])
+
+        return out


### PR DESCRIPTION
Child of #339
Closes #340

- [ ] use seeded tensors in SecureNN
  - [x] int64
  - [x] odd
  - [ ] prime
- [ ] reuse expanded seeds
- [ ] use smaller dtype for binary tensors