### PR TITLE
switch to docker jessie to avoid ABI compatibilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.5-jessie
 
 ARG TF_WHL_URL="https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp35-cp35m-linux_x86_64.whl"
 


### PR DESCRIPTION
Closes https://github.com/mortendahl/tf-encrypted/issues/368

Building the custom op on the base python:3.5 was giving ABI compatibility issues with the official tensorflow build. So switch to jessie which does not have these problems. Related: https://github.com/mortendahl/tf-encrypted/issues/349 and https://github.com/tensorflow/custom-op#docker