### PR TITLE
Securenn examples fixed

### DIFF
--- a/examples/securenn/network_a.py
+++ b/examples/securenn/network_a.py
@@ -42,8 +42,7 @@ class ModelTrainer():
         to_continue = tf.cast(i < max_iter * nb_epochs, tf.bool)
 
         def true_fn() -> tf.Tensor:
-
-            to_continue = tf.print("avg_loss: ",avg_loss)
+            to_continue = tf.print("avg_loss: ", avg_loss)
             return(to_continue)
 
         def false_fn() -> tf.Tensor:

--- a/examples/securenn/network_a.py
+++ b/examples/securenn/network_a.py
@@ -43,7 +43,7 @@ class ModelTrainer():
 
         def true_fn() -> tf.Tensor:
 
-            tf.print(to_continue, data=[avg_loss], message="avg_loss: ")
+            to_continue = tf.print("avg_loss: ",avg_loss)
             return(to_continue)
 
         def false_fn() -> tf.Tensor:
@@ -98,7 +98,8 @@ class ModelTrainer():
         loop, _, _, _ = tf.while_loop(self.cond, loop_body, [0, self.ITERATIONS, self.EPOCHS, 0.])
 
         # return model parameters after training
-        tf.print(loop, [], message="Training complete")
+        loop = tf.print("Training complete", loop)
+
         with tf.control_dependencies([loop]):
             return [param.read_value() for param in params]
 
@@ -131,13 +132,14 @@ class PredictionClient():
             prediction = tf.argmax(likelihoods, axis=1)
             eq_values = tf.equal(prediction, tf.cast(y_true, tf.int64))
             acc = tf.reduce_mean(tf.cast(eq_values, tf.float32))
-            tf.print([], [y_true], summarize=self.BATCH_SIZE, message="EXPECT: ")
-            op=[]
-            tf.print(op, [prediction], summarize=self.BATCH_SIZE, message="ACTUAL: ")
-            op=op
-            tf.print([op], [acc], summarize=self.BATCH_SIZE, message="Acuraccy: ")
-            op=[op]
-            return op
+
+            expect_out = tf.print("EXPECT: ", y_true, summarize=self.BATCH_SIZE)
+
+            actual_out = tf.print("ACTUAL: ", prediction, summarize=self.BATCH_SIZE)
+        
+            accuracy_out = tf.print("Acuraccy: ", acc, summarize=self.BATCH_SIZE)
+      
+            return [expect_out, actual_out, accuracy_out]
 
 
 model_trainer = ModelTrainer()

--- a/examples/securenn/network_a.py
+++ b/examples/securenn/network_a.py
@@ -132,14 +132,9 @@ class PredictionClient():
             prediction = tf.argmax(likelihoods, axis=1)
             eq_values = tf.equal(prediction, tf.cast(y_true, tf.int64))
             acc = tf.reduce_mean(tf.cast(eq_values, tf.float32))
+            op = tf.print('Expected:', y_true, '\nActual:', prediction, '\nAccuracy:', acc)
 
-            expect_out = tf.print("EXPECT: ", y_true, summarize=self.BATCH_SIZE)
-
-            actual_out = tf.print("ACTUAL: ", prediction, summarize=self.BATCH_SIZE)
-        
-            accuracy_out = tf.print("Acuraccy: ", acc, summarize=self.BATCH_SIZE)
-      
-            return [expect_out, actual_out, accuracy_out]
+            return op
 
 
 model_trainer = ModelTrainer()

--- a/examples/securenn/network_b.py
+++ b/examples/securenn/network_b.py
@@ -152,7 +152,7 @@ class PredictionClient():
     def provide_input(self) -> List[tf.Tensor]:
         with tf.name_scope('loading'):
             prediction_input, expected_result = get_data_from_tfrecord("./data/test.tfrecord", self.BATCH_SIZE).get_next()
- 
+
         with tf.name_scope('pre-processing'):
             prediction_input = tf.reshape(prediction_input, shape=(self.BATCH_SIZE, 784))
             expected_result = tf.reshape(expected_result, shape=(self.BATCH_SIZE,))
@@ -164,9 +164,7 @@ class PredictionClient():
             prediction = tf.argmax(likelihoods, axis=1)
             eq_values = tf.equal(prediction, tf.cast(y_true, tf.int64))
             acc = tf.reduce_mean(tf.cast(eq_values, tf.float32))
-
             op = tf.print('Expected:', y_true, '\nActual:', prediction, '\nAccuracy:', acc)
-            #op = tf.print('Expected:', likelihoods)
 
             return op
 
@@ -183,50 +181,41 @@ params = tfe.cache(params)
 # get prediction input from client
 x, y = tfe.define_private_input('prediction-client', prediction_client.provide_input, masked=True)  # pylint: disable=E0632
 
-# helpers
-# conv = lambda x, w: tfe.conv2d(x, w, strides=1, padding='VALID')
-# pool = lambda x: tfe.avgpool2d(x, pool_size=(2, 2), strides=(2, 2), padding='VALID')
-
 
 # compute prediction
 Wconv1, bconv1, Wconv2, bconv2, Wfc1, bfc1, Wfc2, bfc2 = params
 
-cv1_tfe = tfe.layers.Conv2D(
-        input_shape=[-1, 28, 28, 1], filter_shape=[5, 5, 1, 16],
-        strides=1,
-        padding='VALID',
-        channels_first=False
-)
+conv1_tfe = tfe.layers.Conv2D(input_shape=[-1, 28, 28, 1],
+                              filter_shape=[5, 5, 1, 16],
+                              strides=1,
+                              padding='VALID',
+                              channels_first=False)
 
-cv1_tfe.initialize(initial_weights=Wconv1)
+conv1_tfe.initialize(initial_weights=Wconv1)
 
-cv2_tfe = tfe.layers.Conv2D(
-        input_shape=[-1, 12, 12, 16], filter_shape=[5, 5, 16, 16],
-        strides=1,
-        padding='VALID',
-        channels_first=False
-)
+conv2_tfe = tfe.layers.Conv2D(input_shape=[-1, 12, 12, 16],
+                              filter_shape=[5, 5, 16, 16],
+                              strides=1,
+                              padding='VALID',
+                              channels_first=False)
 
-cv2_tfe.initialize(initial_weights=Wconv2)
+conv2_tfe.initialize(initial_weights=Wconv2)
 
-avg1 = tfe.layers.AveragePooling2D(input_shape=[-1, 24, 24, 16],
-                                    pool_size=(2, 2),
-                                    strides=(2,2),
-                                    padding='VALID',
-                                    channels_first=False)
+avg_pool1 = tfe.layers.AveragePooling2D(input_shape=[-1, 24, 24, 16],
+                                        pool_size=(2, 2),
+                                        strides=(2, 2),
+                                        padding='VALID',
+                                        channels_first=False)
 
-avg2 = tfe.layers.AveragePooling2D(input_shape=[-1, 8, 8, 16],
-                                    pool_size=(2, 2),
-                                    strides=(2,2),
-                                    padding='VALID',
-                                    channels_first=False)
+avg_pool1 = tfe.layers.AveragePooling2D(input_shape=[-1, 8, 8, 16],
+                                        pool_size=(2, 2),
+                                        strides=(2, 2),
+                                        padding='VALID',
+                                        channels_first=False)
 
 x = tfe.reshape(x, [-1, 28, 28, 1])
-
-bconv1 = tfe.reshape(bconv1, [1, 1, -1])
-bconv2 = tfe.reshape(bconv2, [1, 1, -1])
-layer1 = avg1.forward(tfe.relu(cv1_tfe.forward(x) + bconv1))
-layer2 = avg2.forward(tfe.relu(cv2_tfe.forward(layer1) + bconv2))
+layer1 = avg_pool1.forward(tfe.relu(conv1_tfe.forward(x) + bconv1))
+layer2 = avg_pool1.forward(tfe.relu(conv2_tfe.forward(layer1) + bconv2))
 
 layer2 = tfe.reshape(layer2, [-1, ModelTrainer.HIDDEN_FC1])
 layer3 = tfe.relu(tfe.matmul(layer2, Wfc1) + bfc1)

--- a/examples/securenn/network_c.py
+++ b/examples/securenn/network_c.py
@@ -169,14 +169,9 @@ class PredictionClient():
             prediction = tf.argmax(likelihoods, axis=1)
             eq_values = tf.equal(prediction, tf.cast(y_true, tf.int64))
             acc = tf.reduce_mean(tf.cast(eq_values, tf.float32))
+            op = tf.print('Expected:', y_true, '\nActual:', prediction, '\nAccuracy:', acc)
 
-            expect_out = tf.print("EXPECT: ", y_true, summarize=self.BATCH_SIZE)
-
-            actual_out = tf.print("ACTUAL: ", prediction, summarize=self.BATCH_SIZE)
-        
-            accuracy_out = tf.print("Acuraccy: ", acc, summarize=self.BATCH_SIZE)
-      
-            return [expect_out, actual_out, accuracy_out]
+            return op
 
 
 model_trainer = ModelTrainer()

--- a/tf_encrypted/layers/convolution.py
+++ b/tf_encrypted/layers/convolution.py
@@ -4,6 +4,8 @@ from typing import List
 
 from . import core
 
+from tf_encrypted.protocol.pond import PondPrivateTensor, PondMaskedTensor
+
 
 class Conv2D(core.Layer):
 
@@ -66,7 +68,12 @@ class Conv2D(core.Layer):
         if initial_weights is None:
             initial_weights = self.filter_init(self.fshape)
 
-        self.weights = self.prot.define_private_variable(initial_weights)
+        if (isinstance(initial_weights, PondPrivateTensor) or 
+            isinstance(initial_weights, PondMaskedTensor)):
+            self.weights = initial_weights
+        else:
+            self.weights = self.prot.define_private_variable(initial_weights)
+
         self.bias = self.prot.define_private_variable(np.zeros(self.output_shape[1:]))
 
     def forward(self, x):

--- a/tf_encrypted/layers/convolution.py
+++ b/tf_encrypted/layers/convolution.py
@@ -68,8 +68,9 @@ class Conv2D(core.Layer):
         if initial_weights is None:
             initial_weights = self.filter_init(self.fshape)
 
-        if (isinstance(initial_weights, PondPrivateTensor) or 
-            isinstance(initial_weights, PondMaskedTensor)):
+        if isinstance(initial_weights, PondPrivateTensor):
+            self.weights = initial_weights
+        elif isinstance(initial_weights, PondMaskedTensor):
             self.weights = initial_weights
         else:
             self.weights = self.prot.define_private_variable(initial_weights)


### PR DESCRIPTION
Hello,

With this pr, the securenn network b and c are now working.  There was a missing relu, and we were using channel last during training for the convolution and pooling layers however we were using channel first for secure inference. 

For plaintext training, I wanted to use channel first in Tensorflow. However I was getting the following error even if I was training on CPU: `Default AvgPoolingOp only supports NHWC on device type CPU`. 

So instead I did channel last for the secure inference part. I used the layer object that gives the option to specify channel last for the convolution and pooling layers instead of using the primitives. 

Thank you!

fixe #248 