### PR TITLE
Make custom ops optional

### DIFF
--- a/operations/secure_random/test_secure_random.py
+++ b/operations/secure_random/test_secure_random.py
@@ -1,19 +1,27 @@
 import unittest
+import os
 
+import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework import errors
-import numpy as np
+from tensorflow.python.framework.errors import NotFoundError
+
 import tf_encrypted as tfe
-import os
+
 
 dirname = os.path.dirname(tfe.__file__)
 shared_object = dirname + '/operations/secure_random/secure_random_module_tf_' + tf.__version__ + '.so'
-secure_random_module = tf.load_op_library(shared_object)
-seeded_random_uniform = secure_random_module.secure_seeded_random_uniform
-random_uniform = secure_random_module.secure_random_uniform
-seed = secure_random_module.secure_seed
+
+try:
+    secure_random_module = tf.load_op_library(shared_object)
+    seeded_random_uniform = secure_random_module.secure_seeded_random_uniform
+    random_uniform = secure_random_module.secure_random_uniform
+    seed = secure_random_module.secure_seed
+except NotFoundError:
+    secure_random_module = None
 
 
+@unittest.skipIf(secure_random_module is None, "secure_random_module not found")
 class TestSeededRandomUniform(unittest.TestCase):
 
     def test_int32_return(self):
@@ -64,6 +72,7 @@ class TestSeededRandomUniform(unittest.TestCase):
             np.testing.assert_array_equal(output, expected)
 
 
+@unittest.skipIf(secure_random_module is None, "secure_random_module not found")
 class TestRandomUniform(unittest.TestCase):
     def test_min_max_range(self):
         with tf.Session():
@@ -96,6 +105,7 @@ class TestRandomUniform(unittest.TestCase):
                 assert(out < 0)
 
 
+@unittest.skipIf(secure_random_module is None, "secure_random_module not found")
 class TestSeed(unittest.TestCase):
     def test_seed(self):
         with tf.Session():

--- a/tests/test_secure_random.py
+++ b/tests/test_secure_random.py
@@ -1,12 +1,15 @@
 import unittest
 
-import tensorflow as tf
 import numpy as np
-from tf_encrypted.operations.secure_random import seeded_random_uniform, random_uniform, seed as seed_gen
+import tensorflow as tf
 
-seed = [87654321, 87654321, 87654321, 87654321, 87654321, 87654321, 87654321, 87654321]
+from tf_encrypted.operations import secure_random
 
 
+SEED = [87654321, 87654321, 87654321, 87654321, 87654321, 87654321, 87654321, 87654321]
+
+
+@unittest.skipUnless(secure_random.supports_seeded_randomness(), "Secure random disabled")
 class TestSeededRandom(unittest.TestCase):
 
     def test_wrapper(self):
@@ -15,7 +18,7 @@ class TestSeededRandom(unittest.TestCase):
                     [9678, 7188, 8280]]
 
         with tf.Session():
-            output = seeded_random_uniform([3, 3], seed=seed, maxval=10000).eval()
+            output = secure_random.seeded_random_uniform([3, 3], seed=SEED, maxval=10000).eval()
 
             np.testing.assert_array_equal(output, expected)
 
@@ -25,7 +28,7 @@ class TestSeededRandom(unittest.TestCase):
                     [9356, 4377, 6561]]
 
         with tf.Session():
-            output = seeded_random_uniform([3, 3], seed=seed, minval=-10000, maxval=10000).eval()
+            output = secure_random.seeded_random_uniform([3, 3], seed=SEED, minval=-10000, maxval=10000).eval()
 
             np.testing.assert_array_equal(output, expected)
 
@@ -33,15 +36,15 @@ class TestSeededRandom(unittest.TestCase):
         with tf.Session():
             # invalid seed
             with np.testing.assert_raises(ValueError):
-                seeded_random_uniform([3, 3], maxval=10000, seed=[1]).eval()
+                secure_random.seeded_random_uniform([3, 3], maxval=10000, seed=[1]).eval()
 
             # invalid maxval
             with np.testing.assert_raises(ValueError):
-                seeded_random_uniform([3, 3]).eval()
+                secure_random.seeded_random_uniform([3, 3]).eval()
 
             # invalid dtype
             with np.testing.assert_raises(ValueError):
-                seeded_random_uniform([3, 3], seed=seed, maxval=10000, dtype=tf.float32).eval()
+                secure_random.seeded_random_uniform([3, 3], seed=SEED, maxval=10000, dtype=tf.float32).eval()
 
     def test_rejection(self):
         m = 1129
@@ -49,23 +52,24 @@ class TestSeededRandom(unittest.TestCase):
         seed0 = [2108217960, -1340439062, 476173466, -681389164, -1502583120, 1663373136, 2144760032, -1591917499]
 
         with tf.Session():
-            out0 = seeded_random_uniform([64, 4500], seed=seed0, maxval=m, dtype=tf.int32).eval()
-            out1 = seeded_random_uniform([64, 4500], seed=seed0, maxval=m, dtype=tf.int32).eval()
+            out0 = secure_random.seeded_random_uniform([64, 4500], seed=seed0, maxval=m, dtype=tf.int32).eval()
+            out1 = secure_random.seeded_random_uniform([64, 4500], seed=seed0, maxval=m, dtype=tf.int32).eval()
 
             np.testing.assert_array_equal(out0, out1)
 
 
+@unittest.skipUnless(secure_random.supports_secure_randomness(), "Secure random disabled")
 class TestRandomUniform(unittest.TestCase):
 
     def test_wrapper(self):
         with tf.Session():
-            output = random_uniform([3, 3], maxval=10000).eval()
+            output = secure_random.random_uniform([3, 3], maxval=10000).eval()
 
             np.testing.assert_array_equal(output.shape, [3, 3])
 
     def test_min_val(self):
         with tf.Session():
-            output = random_uniform([6], minval=-10000, maxval=0).eval()
+            output = secure_random.random_uniform([6], minval=-10000, maxval=0).eval()
 
             for out in output:
                 assert(out < 0)
@@ -74,25 +78,28 @@ class TestRandomUniform(unittest.TestCase):
         with tf.Session():
             # invalid maxval
             with np.testing.assert_raises(ValueError):
-                random_uniform([3, 3]).eval()
+                secure_random.random_uniform([3, 3]).eval()
 
             # invalid dtype
             with np.testing.assert_raises(ValueError):
-                random_uniform([3, 3], maxval=10000, dtype=tf.float32).eval()
+                secure_random.random_uniform([3, 3], maxval=10000, dtype=tf.float32).eval()
 
 
+@unittest.skipUnless(secure_random.supports_seeded_randomness(), "Secure random disabled")
 class TestSeed(unittest.TestCase):
-    with tf.Session():
-        s = seed_gen()
 
-        minval = -2000
-        maxval = 0
+    def test_seed_generation(self):
+        with tf.Session():
+            s = secure_random.seed()
 
-        shape = [2, 3]
+            minval = -2000
+            maxval = 0
 
-        output = seeded_random_uniform(shape, seed=s, minval=minval, maxval=maxval).eval()
+            shape = [2, 3]
 
-        np.testing.assert_array_equal(output.shape, shape)
+            output = secure_random.seeded_random_uniform(shape, seed=s, minval=minval, maxval=maxval).eval()
+
+            np.testing.assert_array_equal(output.shape, shape)
 
 
 if __name__ == '__main__':

--- a/tf_encrypted/operations/secure_random/__init__.py
+++ b/tf_encrypted/operations/secure_random/__init__.py
@@ -1,6 +1,11 @@
-from .secure_random import seeded_random_uniform, random_uniform, seed
+from .secure_random import (
+    seeded_random_uniform, random_uniform, seed,
+    supports_secure_randomness, supports_seeded_randomness
+)
 
 __all__ = [
+    "supports_secure_randomness",
+    "supports_seeded_randomness",
     "seeded_random_uniform",
     "random_uniform",
     "seed"

--- a/tf_encrypted/operations/secure_random/secure_random.py
+++ b/tf_encrypted/operations/secure_random/secure_random.py
@@ -1,9 +1,13 @@
+import logging
+import os
+
 import tensorflow as tf
 import tf_encrypted as tfe
+
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework.errors import NotFoundError
-import os
+
 
 dirname = os.path.dirname(tfe.__file__)
 shared_object = dirname + '/operations/secure_random/secure_random_module_tf_' + tf.__version__ + '.so'
@@ -11,8 +15,18 @@ shared_object = dirname + '/operations/secure_random/secure_random_module_tf_' +
 try:
     secure_random_module = tf.load_op_library(shared_object)
 except NotFoundError:
-    raise Exception("Could not find the secure random shared object for the installed "
-                    "tensorflow version " + tf.__version__)
+    logging.warning("Falling back to insecure randomness since required custom op could not be "
+                    "found for the installed version of TensorFlow (" + tf.__version__ + "). "
+                    "Fix this by compiling custom ops.")
+    secure_random_module = None
+
+
+def supports_secure_randomness():
+    return secure_random_module is not None
+
+
+def supports_seeded_randomness():
+    return secure_random_module is not None
 
 
 def seeded_random_uniform(shape, minval=0, maxval=None, dtype=tf.int32, seed=None, name=None):

--- a/tf_encrypted/operations/secure_random/secure_random.py
+++ b/tf_encrypted/operations/secure_random/secure_random.py
@@ -15,9 +15,10 @@ shared_object = dirname + '/operations/secure_random/secure_random_module_tf_' +
 try:
     secure_random_module = tf.load_op_library(shared_object)
 except NotFoundError:
-    logging.warning("Falling back to insecure randomness since required custom op could not be "
-                    "found for the installed version of TensorFlow (" + tf.__version__ + "). "
-                    "Fix this by compiling custom ops.")
+    logging.warning(
+        "Falling back to insecure randomness since required custom op could not be "
+        "found for the installed version of TensorFlow (" + tf.__version__ + "). "
+        "Fix this by compiling custom ops.")
     secure_random_module = None
 
 

--- a/tf_encrypted/protocol/pond.py
+++ b/tf_encrypted/protocol/pond.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from typing import Tuple, List, Union, Optional, Any, NewType, Callable
 import abc
 import sys
+import logging
 from math import log2, ceil
 from random import random
 
@@ -70,6 +71,10 @@ class Pond(Protocol):
             if tensorflow_supports_int64():
                 tensor_factory = int64factory
             else:
+                logging.warning(
+                    "Falling back to using int100 tensors due to lack of int64 support. "
+                    "Performance may be improved by installing a version of TensorFlow "
+                    "supporting this (1.13+ or custom build).")
                 tensor_factory = int100factory
 
         if fixedpoint_config is None:


### PR DESCRIPTION
Changes making custom ops (`secure_random`) optional, with warnings if not used.

Depends on #381 
Needed by #376 
Closes #334