### PR TITLE
Conv2d - fix strides input - converter

### DIFF
--- a/tf_encrypted/convert/register.py
+++ b/tf_encrypted/convert/register.py
@@ -111,7 +111,7 @@ def conv2d(converter: Converter, node: Any, inputs: List[str]) -> Any:
 
     layer = Conv2D(
         input.shape.as_list(), shape,
-        strides=int(node.attr["strides"].list.i[0]),
+        strides=int(max(node.attr["strides"].list.i)),
         padding=node.attr["padding"].s.decode('ascii'),
         channels_first=format == "NCHW"
     )


### PR DESCRIPTION
Hey @jvmancuso , 

There was an issue with the strides input for the conv2d layer. For example for stride = 2, the strides input would look like `[1, 2, 2, 1]`. But we were taking only at the first element so the stride was equal to 1. 

Thanks,

 