### PR TITLE
Fix small typos in docs

### DIFF
--- a/docs/source/guides/mnist.rst
+++ b/docs/source/guides/mnist.rst
@@ -3,8 +3,8 @@ MNIST
 
 This tutorial is also available on `Google Collab`_, feel free to follow along there!
 
-In this tutorial, we will train our model in plaintext with Tensorflow, then
-make private predictions with TF Encrypted. we will use the `MNIST dataset`_.
+In this tutorial, we will train our model in plaintext with TensorFlow, then
+make private predictions with TF Encrypted. We will use the `MNIST dataset`_.
 
 .. _Google Collab: https://colab.research.google.com/drive/1BbOcMc8npAfQH91-2jtCWkTvpXY0aThC
 .. _MNIST dataset: http://yann.lecun.com/exdb/mnist/
@@ -323,5 +323,5 @@ and TensorFlow follow a very similar API
             sess.run(prediction_op, tag='prediction')
 
 
-And voila! you have just trained a model in plaintext then made private predictions
+And voila! You have just trained a model in plaintext then made private predictions
 without revealing anything about the input!

--- a/docs/source/usage/getting_started.rst
+++ b/docs/source/usage/getting_started.rst
@@ -1,22 +1,22 @@
 Getting Started
 ================
 
-This walkthrough assumes that you have installed `tf-encrypted` by following the `installation instructions`_.
+This walkthrough assumes that you have installed TF Encrypted by following the `installation instructions`_.
 
 .. _installation instructions: installation.html
 
-`tf-encrypted` is a `secure multiparty computation`_ library where multiple people (or "`parties`") work together to compute results in a secure fashion without any one party having access to the underlying data. This is achieved by splitting up the input data into shares that are `perfectly secure`_.
+TF Encrypted is a `secure multiparty computation`_ library where multiple people (or "`parties`") work together to compute results in a secure fashion without any one party having access to the underlying data. This is achieved by splitting up the input data into shares that are `perfectly secure`_.
 
 .. _secure multiparty computation: https://en.wikipedia.org/wiki/Secure_multi-party_computation
 .. _perfectly secure: https://en.wikipedia.org/wiki/One-time_pad
 
 --------------------------------------------
-Introduction to tf-encrypted's API
+Introduction to TF Encrypted's API
 --------------------------------------------
 
-tf-encrypted provides an API similar to TensorFlow that data scientists and researchers can use to train models and predict upon them in privacy-preserving fashion.
+TF Encrypted provides an API similar to TensorFlow that data scientists and researchers can use to train models and predict upon them in privacy-preserving fashion.
 
-One of the goals of tf-encrypted is to make experimenting with secure private machine learning accessible to anyone. To do this, we've implemented an API that is very similar to TensorFlow while abstracting away the complexity of securely managing public and private data. The `PondTensor` is the primary abstraction provided for managing public and private data.
+One of the goals of TF Encrypted is to make experimenting with secure private machine learning accessible to anyone. To do this, we've implemented an API that is very similar to TensorFlow while abstracting away the complexity of securely managing public and private data. The `PondTensor` is the primary abstraction provided for managing public and private data.
 
 The following example demonstrates constructing a public value (known to all parties) using `tfe.define_public_variable`.
 
@@ -59,7 +59,7 @@ Similar to public variables we can define private variables as demonstrated belo
 
 Unlike with public tensors, each node involved in a computation will get a different share of the encrypted (private) data. This sharing mechanism is the backbone of multiparty computation.
 
-For more indepth examples of how to use `tf-encrypted` to train and predict upon machine learning models please check out our `MNIST`_ or `Logistic Regression`_ guies.
+For more in depth examples of how to use TF Encrypted to train and predict upon machine learning models please check out our `MNIST`_ or `Logistic Regression`_ guides.
 
 If you have any questions, please don't hesitate to reach out via a `GitHub Issue`_.
 

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -1,17 +1,17 @@
 Installation
 =============
 
-tf-encrypted is available as a package on `PyPA`_ and supports Python 3.5+ and tensorflow 1.12.0+. You can install the package using pip::
+TF Encrypted is available as a package on `PyPA`_ and supports Python 3.5+ and tensorflow 1.12.0+. You can install the package using pip::
 
    pip install tf-encrypted
 
-A `change log`_ is kept for each version of tf-encrypted released which can be found on `GitHub`_.
+A `change log`_ is kept for each version of TF Encrypted released which can be found on `GitHub`_.
 
 Once installed, you can import the package into your code as shown below::
 
    import tf_encrypted as tfe
 
-To learn how to use tf-encrypted to perform encrypted machine learning checkout our `Getting Started`_ guide.
+To learn how to use TF Encrypted to perform encrypted machine learning checkout our `Getting Started`_ guide.
 
 .. _PyPA: https://pypi.org/project/tf-encrypted
 .. _Getting Started: getting_started.html


### PR DESCRIPTION
Also be consistent about usage of `tf-encrypted` vs TF Encrypted.