### PR TITLE
tf.negative

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ recommonmark==0.4.0
 google-cloud-storage==1.13.1
 pytest==4.2.0
 pytest-xdist==1.26.1
+nose==1.3.7

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -112,6 +112,10 @@ class TestConvert(unittest.TestCase):
         test_input = np.ones([1, 28])
         self._test_with_ndarray_input_fn('matmul', test_input, protocol='Pond')
 
+    def test_neg_convert(self):
+        test_input = np.ones([2, 2])
+        self._test_with_ndarray_input_fn('neg', test_input, protocol='Pond')
+
     def test_add_convert(self):
         test_input = np.ones([28, 1])
         self._test_with_ndarray_input_fn('add', test_input, protocol='Pond')
@@ -361,6 +365,25 @@ def export_matmul(filename: str, input_shape: List[int]):
     x = tf.matmul(a, b)
 
     return export(x, filename)
+
+
+def export_neg(filename: str, input_shape: List[int]):
+    a = tf.placeholder(tf.float32, shape=input_shape, name="input")
+
+    x = tf.negative(a)
+
+    return export(x, filename)
+
+
+def run_neg(input):
+    a = tf.placeholder(tf.float32, shape=input.shape, name="input")
+
+    x = tf.negative(a)
+
+    with tf.Session() as sess:
+        output = sess.run(x, feed_dict={a: input})
+
+    return output
 
 
 def run_add(input):

--- a/tests/test_neg.py
+++ b/tests/test_neg.py
@@ -5,11 +5,11 @@ import tensorflow as tf
 import tf_encrypted as tfe
 
 
-class TestReshape(unittest.TestCase):
+class TestNegative(unittest.TestCase):
     def setUp(self):
         tf.reset_default_graph()
 
-    def test_forward(self):
+    def test_negative(self):
         input_shape = [2, 2]
         input_neg = np.ones(input_shape)
 
@@ -18,7 +18,7 @@ class TestReshape(unittest.TestCase):
 
             neg_input = prot.define_private_variable(input_neg)
 
-            neg_out_pond = prot.neg(neg_input)
+            neg_out_pond = prot.negative(neg_input)
 
             with tfe.Session() as sess:
 

--- a/tests/test_neg.py
+++ b/tests/test_neg.py
@@ -1,0 +1,45 @@
+import unittest
+
+import numpy as np
+import tensorflow as tf
+import tf_encrypted as tfe
+
+
+class TestReshape(unittest.TestCase):
+    def setUp(self):
+        tf.reset_default_graph()
+
+    def test_forward(self):
+        input_shape = [2, 2]
+        input_neg = np.ones(input_shape)
+
+        # reshape pond
+        with tfe.protocol.Pond() as prot:
+
+            neg_input = prot.define_private_variable(input_neg)
+
+            neg_out_pond = prot.neg(neg_input)
+
+            with tfe.Session() as sess:
+
+                sess.run(tf.global_variables_initializer())
+                # outputs
+                out_pond = sess.run(neg_out_pond.reveal())
+
+            # reset graph
+            tf.reset_default_graph()
+
+            with tf.Session() as sess:
+                x = tf.Variable(input_neg, dtype=tf.float32)
+
+                neg_out_tf = tf.negative(x)
+
+                sess.run(tf.global_variables_initializer())
+
+                out_tensorflow = sess.run(neg_out_tf)
+
+        assert(np.isclose(out_pond, out_tensorflow, atol=0.6).all())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tf_encrypted/convert/register.py
+++ b/tf_encrypted/convert/register.py
@@ -39,7 +39,7 @@ def register() -> Dict[str, Any]:
         'required_space_to_batch_paddings': required_space_to_batch_paddings,
         'flatten': flatten,
         'Slice': slice,
-        'Neg': neg,
+        'Neg': negative,
     }
 
     return reg
@@ -273,7 +273,7 @@ def expand_dims(converter: Converter, node: Any, inputs: List[str]) -> Any:
     return converter.protocol.expand_dims(input_out, axis_val)
 
 
-def neg(converter: Converter, node: Any, inputs: List[str]) -> Any:
+def negative(converter: Converter, node: Any, inputs: List[str]) -> Any:
     input = converter.outputs[inputs[0]]
 
     if isinstance(input, tf.NodeDef):
@@ -281,7 +281,7 @@ def neg(converter: Converter, node: Any, inputs: List[str]) -> Any:
     else:
         input_out = input
 
-    return converter.protocol.neg(input_out)
+    return converter.protocol.negative(input_out)
 
 
 def squeeze(converter: Converter, node: Any, inputs: List[str]) -> Any:

--- a/tf_encrypted/convert/register.py
+++ b/tf_encrypted/convert/register.py
@@ -277,7 +277,7 @@ def neg(converter: Converter, node: Any, inputs: List[str]) -> Any:
     input = converter.outputs[inputs[0]]
 
     if isinstance(input, tf.NodeDef):
-        input_out = nodef_to_public_pond(converter, input)
+        input_out = nodef_to_private_pond(converter, input)
     else:
         input_out = input
 

--- a/tf_encrypted/convert/register.py
+++ b/tf_encrypted/convert/register.py
@@ -39,6 +39,7 @@ def register() -> Dict[str, Any]:
         'required_space_to_batch_paddings': required_space_to_batch_paddings,
         'flatten': flatten,
         'Slice': slice,
+        'Neg': neg,
     }
 
     return reg
@@ -270,6 +271,17 @@ def expand_dims(converter: Converter, node: Any, inputs: List[str]) -> Any:
     axis_val = array.array('i', axis_attr)[0]
 
     return converter.protocol.expand_dims(input_out, axis_val)
+
+
+def neg(converter: Converter, node: Any, inputs: List[str]) -> Any:
+    input = converter.outputs[inputs[0]]
+
+    if isinstance(input, tf.NodeDef):
+        input_out = nodef_to_public_pond(converter, input)
+    else:
+        input_out = input
+
+    return converter.protocol.neg(input_out)
 
 
 def squeeze(converter: Converter, node: Any, inputs: List[str]) -> Any:

--- a/tf_encrypted/protocol/pond.py
+++ b/tf_encrypted/protocol/pond.py
@@ -841,25 +841,15 @@ class Pond(Protocol):
         raise TypeError("Don't know how to reshape {}".format(type(x)))
 
     @memoize
-    def neg(self, x: "PondTensor"):
+    def negative(self, x: "PondTensor"):
         """
-        neg(x) -> PondTensor
+        negative(x) -> PondTensor
 
         Computes numerical negative value element-wise.
 
         :param PondTensor x: Input tensor.
         """
-
-        if isinstance(x, PondPublicTensor):
-            return _neg_public(self, x)
-
-        if isinstance(x, PondPrivateTensor):
-            return _neg_private(self, x)
-
-        if isinstance(x, PondMaskedTensor):
-            return _neg_masked(self, x)
-
-        raise TypeError("Don't know how to reshape {}".format(type(x)))
+        return self.dispatch("negative", x)
 
     @memoize
     def expand_dims(self, x: "PondTensor", axis=None):
@@ -1426,14 +1416,14 @@ class PondTensor(abc.ABC):
         """
         return self.prot.reshape(self, shape)
 
-    def neg(self) -> "PondTensor":
+    def negative(self) -> "PondTensor":
         """
         :See: tf.negative
 
         :rtype: PondTensor
         :returns: A new tensor with numerical negative value element-wise computed.
         """
-        return self.prot.neg(self)
+        return self.prot.negative(self)
 
     def reduce_max(self, axis: int) -> "PondTensor":
         """
@@ -3557,73 +3547,73 @@ def _reshape_masked(
         )
 
 #
-# neg helpers
+# negative helpers
 #
 
 
-def _neg_public(
+def _negative_public(
     prot: Pond, x: PondPublicTensor
 ) -> PondPublicTensor:
     assert isinstance(x, PondPublicTensor)
 
     x_on_0, x_on_1 = x.unwrapped
 
-    with tf.name_scope("neg"):
+    with tf.name_scope("negative"):
 
         with tf.device(prot.server_0.device_name):
-            x_on_0_neg = x_on_0.neg()
+            x_on_0_negative = x_on_0.negative()
 
         with tf.device(prot.server_1.device_name):
-            x_on_1_neg = x_on_1.neg()
+            x_on_1_negative = x_on_1.negative()
 
-        return PondPublicTensor(prot, x_on_0_neg, x_on_1_neg, x.is_scaled)
+        return PondPublicTensor(prot, x_on_0_negative, x_on_1_negative, x.is_scaled)
 
 
-def _neg_private(
+def _negative_private(
     prot: Pond, x: PondPrivateTensor
 ) -> PondPrivateTensor:
     assert isinstance(x, PondPrivateTensor)
 
     x0, x1 = x.unwrapped
 
-    with tf.name_scope("neg"):
+    with tf.name_scope("negative"):
 
         with tf.device(prot.server_0.device_name):
-            x0_neg = x0.neg()
+            x0_negative = x0.negative()
 
         with tf.device(prot.server_1.device_name):
-            x1_neg = x1.neg()
+            x1_negative = x1.negative()
 
-        return PondPrivateTensor(prot, x0_neg, x1_neg, x.is_scaled)
+        return PondPrivateTensor(prot, x0_negative, x1_negative, x.is_scaled)
 
 
-def _neg_masked(
+def _negative_masked(
     prot: Pond, x: PondMaskedTensor
 ) -> PondMaskedTensor:
     assert isinstance(x, PondMaskedTensor)
     a, a0, a1, alpha_on_0, alpha_on_1 = x.unwrapped
 
-    with tf.name_scope("neg"):
+    with tf.name_scope("negative"):
 
         with tf.device(prot.crypto_producer.device_name):
-            a_neg = a.neg()
+            a_negative = a.negative()
 
         with tf.device(prot.server_0.device_name):
-            a0_neg = a0.neg()
-            alpha_on_0_neg = alpha_on_0.neg()
+            a0_negative = a0.negative()
+            alpha_on_0_negative = alpha_on_0.negative()
 
         with tf.device(prot.server_1.device_name):
-            a1_neg = a1.neg()
-            alpha_on_1_neg = alpha_on_1.neg()
+            a1_negative = a1.negative()
+            alpha_on_1_negative = alpha_on_1.negative()
 
         return PondMaskedTensor(
             prot,
-            prot.neg(x.unmasked),
-            a_neg,
-            a0_neg,
-            a1_neg,
-            alpha_on_0_neg,
-            alpha_on_1_neg,
+            prot.negative(x.unmasked),
+            a_negative,
+            a0_negative,
+            a1_negative,
+            alpha_on_0_negative,
+            alpha_on_1_negative,
             x.is_scaled,
         )
 

--- a/tf_encrypted/protocol/pond.py
+++ b/tf_encrypted/protocol/pond.py
@@ -843,12 +843,11 @@ class Pond(Protocol):
     @memoize
     def neg(self, x: "PondTensor"):
         """
-        reshape(x, shape) -> PondTensor
+        neg(x) -> PondTensor
 
-        Reshape `x` into a tensor with a new `shape`.
+        Computes numerical negative value element-wise.
 
         :param PondTensor x: Input tensor.
-        :param (int,...) shape: Shape of output tensor.
         """
 
         if isinstance(x, PondPublicTensor):
@@ -1429,11 +1428,10 @@ class PondTensor(abc.ABC):
 
     def neg(self) -> "PondTensor":
         """
-        :See: tf.neg
+        :See: tf.negative
 
-        :param List[int] shape: The new shape of the tensor.
         :rtype: PondTensor
-        :returns: A new tensor with the contents of this tensor, but with the new specified shape.
+        :returns: A new tensor with numerical negative value element-wise computed.
         """
         return self.prot.neg(self)
 

--- a/tf_encrypted/protocol/securenn/securenn.py
+++ b/tf_encrypted/protocol/securenn/securenn.py
@@ -169,7 +169,7 @@ class SecureNN(Pond):
         return self.dispatch('bits', x, container=_thismodule, factory=factory)
 
     @memoize
-    def negative(self, x: PondTensor) -> PondTensor:
+    def is_negative(self, x: PondTensor) -> PondTensor:
         """
         Returns :math:`x < 0`.
 
@@ -180,7 +180,7 @@ class SecureNN(Pond):
 
         :param PondTensor x: The tensor to check.
         """
-        with tf.name_scope('negative'):
+        with tf.name_scope('is_negative'):
             # NOTE MSB is 1 iff xi < 0
             return self.msb(x)
 
@@ -219,7 +219,7 @@ class SecureNN(Pond):
         :param PondTensor y: The tensor to check against.
         """
         with tf.name_scope('less'):
-            return self.negative(x - y)
+            return self.is_negative(x - y)
 
     @memoize
     def less_equal(self, x: PondTensor, y: PondTensor) -> PondTensor:
@@ -255,7 +255,7 @@ class SecureNN(Pond):
         :param PondTensor y: The tensor to check against.
         """
         with tf.name_scope('greater'):
-            return self.negative(y - x)
+            return self.is_negative(y - x)
 
     @memoize
     def greater_equal(self, x: PondTensor, y: PondTensor) -> PondTensor:

--- a/tf_encrypted/tensor/int100.py
+++ b/tf_encrypted/tensor/int100.py
@@ -576,6 +576,10 @@ def crt_factory(INT_TYPE, MODULI):
             backing = [tf.reshape(xi, axes) for xi in self.backing]
             return DenseTensor(backing)
 
+        def neg(self):
+            backing = [tf.math.negative(xi) for xi in self.backing]
+            return DenseTensor(backing)
+
         def expand_dims(self, axis: Optional[int] = None):
             backing = [tf.expand_dims(xi, axis) for xi in self.backing]
             return DenseTensor(backing)

--- a/tf_encrypted/tensor/int100.py
+++ b/tf_encrypted/tensor/int100.py
@@ -577,7 +577,7 @@ def crt_factory(INT_TYPE, MODULI):
             return DenseTensor(backing)
 
         def negative(self):
-            backing = [tf.math.negative(xi) for xi in self.backing]
+            backing = [tf.negative(xi) % mi for xi, mi in zip(self.backing, MODULI)]
             return DenseTensor(backing)
 
         def expand_dims(self, axis: Optional[int] = None):
@@ -587,10 +587,6 @@ def crt_factory(INT_TYPE, MODULI):
         def squeeze(self, axis: Optional[List[int]] = None):
             backing = [tf.squeeze(xi, axis=axis) for xi in self.backing]
             return DenseTensor(backing)
-
-        # def negative(self):
-        #     # TODO[Morten] there's probably a more efficient way
-        #     return FACTORY.zero() - self
 
         def truncate(self, amount, base=2):
             factor = base**amount

--- a/tf_encrypted/tensor/int100.py
+++ b/tf_encrypted/tensor/int100.py
@@ -576,7 +576,7 @@ def crt_factory(INT_TYPE, MODULI):
             backing = [tf.reshape(xi, axes) for xi in self.backing]
             return DenseTensor(backing)
 
-        def neg(self):
+        def negative(self):
             backing = [tf.math.negative(xi) for xi in self.backing]
             return DenseTensor(backing)
 
@@ -588,9 +588,9 @@ def crt_factory(INT_TYPE, MODULI):
             backing = [tf.squeeze(xi, axis=axis) for xi in self.backing]
             return DenseTensor(backing)
 
-        def negative(self):
-            # TODO[Morten] there's probably a more efficient way
-            return FACTORY.zero() - self
+        # def negative(self):
+        #     # TODO[Morten] there's probably a more efficient way
+        #     return FACTORY.zero() - self
 
         def truncate(self, amount, base=2):
             factor = base**amount

--- a/tf_encrypted/tensor/native.py
+++ b/tf_encrypted/tensor/native.py
@@ -290,6 +290,9 @@ def native_factory(NATIVE_TYPE, EXPLICIT_MODULUS=None):
         def reshape(self, axes: Union[tf.Tensor, List[int]]):
             return DenseTensor(tf.reshape(self.value, axes))
 
+        def neg(self):
+            return DenseTensor(tf.negative(self.value))
+
         def reduce_sum(self, axis, keepdims=None):
             value = tf.reduce_sum(self.value, axis, keepdims)
             if EXPLICIT_MODULUS is not None:

--- a/tf_encrypted/tensor/native.py
+++ b/tf_encrypted/tensor/native.py
@@ -291,7 +291,10 @@ def native_factory(NATIVE_TYPE, EXPLICIT_MODULUS=None):
             return DenseTensor(tf.reshape(self.value, axes))
 
         def negative(self):
-            return DenseTensor(tf.negative(self.value))
+            value = tf.negative(self.value)
+            if EXPLICIT_MODULUS is not None:
+                value %= EXPLICIT_MODULUS
+            return DenseTensor(value)
 
         def reduce_sum(self, axis, keepdims=None):
             value = tf.reduce_sum(self.value, axis, keepdims)
@@ -335,12 +338,6 @@ def native_factory(NATIVE_TYPE, EXPLICIT_MODULUS=None):
 
         def squeeze(self, axis: Optional[List[int]] = None):
             return DenseTensor(tf.squeeze(self.value, axis=axis))
-
-        # def negative(self):
-        #     value = tf.negative(self.value)
-        #     if EXPLICIT_MODULUS is not None:
-        #         value %= EXPLICIT_MODULUS
-        #     return DenseTensor(value)
 
         def cast(self, factory):
             return factory.tensor(self.value)

--- a/tf_encrypted/tensor/native.py
+++ b/tf_encrypted/tensor/native.py
@@ -290,7 +290,7 @@ def native_factory(NATIVE_TYPE, EXPLICIT_MODULUS=None):
         def reshape(self, axes: Union[tf.Tensor, List[int]]):
             return DenseTensor(tf.reshape(self.value, axes))
 
-        def neg(self):
+        def negative(self):
             return DenseTensor(tf.negative(self.value))
 
         def reduce_sum(self, axis, keepdims=None):
@@ -336,11 +336,11 @@ def native_factory(NATIVE_TYPE, EXPLICIT_MODULUS=None):
         def squeeze(self, axis: Optional[List[int]] = None):
             return DenseTensor(tf.squeeze(self.value, axis=axis))
 
-        def negative(self):
-            value = tf.negative(self.value)
-            if EXPLICIT_MODULUS is not None:
-                value %= EXPLICIT_MODULUS
-            return DenseTensor(value)
+        # def negative(self):
+        #     value = tf.negative(self.value)
+        #     if EXPLICIT_MODULUS is not None:
+        #         value %= EXPLICIT_MODULUS
+        #     return DenseTensor(value)
 
         def cast(self, factory):
             return factory.tensor(self.value)


### PR DESCRIPTION
Hey @mortendahl,

This PR implements the [tf.negative](https://www.tensorflow.org/api_docs/python/tf/math/negative) operation (`tf.negative([-1, 0, 1]) == [1, 0, -1]`). I named it `neg` so it doesn't get mixed with the negative operation in the securenn protocol (`negative([-1, 0, 1]) == [1, 0, 0]`).  

This operation appeared in one of the convolution network when I turned off in the batchnorm layer the parameters scale and offset. 

Thanks!
