### PR TITLE
peg tensorflow requirement to 1.x (errors w/ tf 2.0.0-alpha0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ setuptools.setup(
     ]},
     python_requires=">=3.5",
     install_requires=[
-        "tensorflow>=1.12.0",
+        "tensorflow>=1.12.0,<2",
         "numpy>=1.14.0"
     ],
     extra_requires={
-        "tf": ["tensorflow>=1.12.0"]
+        "tf": ["tensorflow>=1.12.0,<2"]
     },
     license="Apache License 2.0",
     url="https://github.com/mortendahl/tf-encrypted",


### PR DESCRIPTION
I installed tensorflow 2.0.0-alpha0 while setting up this project and that resulted in some errors using tf-encrypted like `AttributeError: module 'tensorflow' has no attribute 'Session'`. I pegged the tensorflow requirement so that until forwards compatibility is implemented running `pip3 install -e .` will ensure that a compatible version is installed. 